### PR TITLE
[FEAT] User 엔티티 및 도메인 계층 구현

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./gradlew bootRun:*)",
-      "Bash(./gradlew dependencies:*)",
-      "WebSearch"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 
-application.yaml
+### Claude Code ###
+.claude/
+
+### application.yaml ###
+*.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -37,15 +37,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Mybatis
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:4.0.1'
+	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:4.0.1'
 
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// H2 Database for testing
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/buncheoleasy/global/exception/domain/BusinessException.java
+++ b/src/main/java/buncheoleasy/global/exception/domain/BusinessException.java
@@ -1,0 +1,24 @@
+package buncheoleasy.global.exception.domain;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(final ErrorCode errorCode, final Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(final ErrorCode errorCode, final String dynamicMessage) {
+        super(dynamicMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/buncheoleasy/global/exception/domain/ErrorCode.java
+++ b/src/main/java/buncheoleasy/global/exception/domain/ErrorCode.java
@@ -13,15 +13,15 @@ public enum ErrorCode {
      * USR - 유저 관련 에러
      */
     USER_SOCIAL_ID_REQUIRED("USR-001", "소셜 고유 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
-    USER_SOCIAL_ID_LENGTH_INVALID("USR-002", "소셜 고유 ID는 64자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_SOCIAL_ID_LENGTH_INVALID("USR-002", "소셜 고유 ID는 100자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
     USER_SOCIAL_ID_FORMAT_INVALID("USR-003", "소셜 고유 ID는 영문자, 숫자, 언더스코어(_), 하이픈(-)만 사용 가능합니다.", HttpStatus.BAD_REQUEST),
 
     USER_NICKNAME_REQUIRED("USR-004", "닉네임은 필수입니다.", HttpStatus.BAD_REQUEST),
-    USER_NICKNAME_LENGTH_INVALID("USR-005", "닉네임은 1자 이상 10자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_NICKNAME_LENGTH_INVALID("USR-005", "닉네임은 1자 이상 20자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
     USER_NICKNAME_FORMAT_INVALID("USR-006", "닉네임은 한글, 영문자, 숫자만 사용 가능합니다.", HttpStatus.BAD_REQUEST),
 
     USER_EMAIL_REQUIRED("USR-007", "이메일은 필수입니다.", HttpStatus.BAD_REQUEST),
-    USER_EMAIL_LENGTH_INVALID("USR-008", "이메일은 255자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_EMAIL_LENGTH_INVALID("USR-008", "이메일은 320자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
     USER_EMAIL_FORMAT_INVALID("USR-009", "올바른 이메일 형식이 아닙니다.", HttpStatus.BAD_REQUEST),
 
     USER_PHONE_NUMBER_REQUIRED("USR-010", "전화번호는 필수입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/buncheoleasy/global/exception/domain/ErrorCode.java
+++ b/src/main/java/buncheoleasy/global/exception/domain/ErrorCode.java
@@ -1,0 +1,53 @@
+package buncheoleasy.global.exception.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    /**
+     * USR - 유저 관련 에러
+     */
+    USER_SOCIAL_ID_REQUIRED("USR-001", "소셜 고유 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
+    USER_SOCIAL_ID_LENGTH_INVALID("USR-002", "소셜 고유 ID는 64자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_SOCIAL_ID_FORMAT_INVALID("USR-003", "소셜 고유 ID는 영문자, 숫자, 언더스코어(_), 하이픈(-)만 사용 가능합니다.", HttpStatus.BAD_REQUEST),
+
+    USER_NICKNAME_REQUIRED("USR-004", "닉네임은 필수입니다.", HttpStatus.BAD_REQUEST),
+    USER_NICKNAME_LENGTH_INVALID("USR-005", "닉네임은 1자 이상 10자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_NICKNAME_FORMAT_INVALID("USR-006", "닉네임은 한글, 영문자, 숫자만 사용 가능합니다.", HttpStatus.BAD_REQUEST),
+
+    USER_EMAIL_REQUIRED("USR-007", "이메일은 필수입니다.", HttpStatus.BAD_REQUEST),
+    USER_EMAIL_LENGTH_INVALID("USR-008", "이메일은 255자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_EMAIL_FORMAT_INVALID("USR-009", "올바른 이메일 형식이 아닙니다.", HttpStatus.BAD_REQUEST),
+
+    USER_PHONE_NUMBER_REQUIRED("USR-010", "전화번호는 필수입니다.", HttpStatus.BAD_REQUEST),
+    USER_PHONE_NUMBER_LENGTH_INVALID("USR-011", "전화번호는 10자 또는 11자여야 합니다.", HttpStatus.BAD_REQUEST),
+    USER_PHONE_NUMBER_FORMAT_INVALID("USR-012", "올바른 전화번호 형식이 아닙니다. (예: 01012345678)", HttpStatus.BAD_REQUEST),
+
+    USER_NICKNAME_UNCHANGED("USR-013", "변경할 닉네임이 현재 닉네임과 동일합니다.", HttpStatus.BAD_REQUEST),
+    USER_PHONE_NUMBER_UNCHANGED("USR-014", "변경할 전화번호가 현재 전화번호와 동일합니다.", HttpStatus.BAD_REQUEST),
+    USER_NICKNAME_DUPLICATE("USR-015", "이미 다른 사용자가 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+
+    PROVIDER_REQUIRED("USR-016", "소셜 로그인 제공자는 필수입니다.", HttpStatus.BAD_REQUEST),
+    PROVIDER_NOT_FOUND("USR-017", "지원하지 않는 소셜 로그인 제공자입니다.", HttpStatus.BAD_REQUEST),
+    
+    /**
+     * C - 공통 에러
+     */
+    INVALID_INPUT_VALUE("C-001", "적절하지 않은 입력값입니다.", HttpStatus.BAD_REQUEST),
+    INTERNAL_SERVER_ERROR("C-002", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public ProblemDetail toProblemDetail() {
+        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(httpStatus, message);
+        problemDetail.setProperty("code", code);
+        return problemDetail;
+    }
+}

--- a/src/main/java/buncheoleasy/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/buncheoleasy/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package buncheoleasy.global.exception.handler;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /*
+    비즈니스 로직 수행 과정에서 발생하는 모든 예외 처리
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ProblemDetail handleBusinessException(final BusinessException exception) {
+        return exception.getErrorCode().toProblemDetail();
+    }
+
+    /*
+    @Valid 어노테이션을 사용한 요청 검증에 실패한 경우 발생하는 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handle(final MethodArgumentNotValidException exception) {
+        return ErrorCode.INVALID_INPUT_VALUE.toProblemDetail();
+    }
+}

--- a/src/main/java/buncheoleasy/user/application/UserService.java
+++ b/src/main/java/buncheoleasy/user/application/UserService.java
@@ -1,0 +1,15 @@
+package buncheoleasy.user.application;
+
+import buncheoleasy.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+}

--- a/src/main/java/buncheoleasy/user/domain/Email.java
+++ b/src/main/java/buncheoleasy/user/domain/Email.java
@@ -1,0 +1,46 @@
+package buncheoleasy.user.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record Email(String value) {
+
+    private static final Pattern EMAIL_REGEX = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final int MAX_LENGTH = 320;
+
+    public Email {
+        validateValue(value);
+    }
+
+    public static Email of(final String value) {
+        return new Email(value);
+    }
+
+    private void validateValue(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.USER_EMAIL_REQUIRED);
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new BusinessException(ErrorCode.USER_EMAIL_LENGTH_INVALID);
+        }
+        if (!EMAIL_REGEX.matcher(value).matches()) {
+            throw new BusinessException(ErrorCode.USER_EMAIL_FORMAT_INVALID);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Email email = (Email) o;
+        return Objects.equals(this.value, email.value);
+    }
+
+}

--- a/src/main/java/buncheoleasy/user/domain/Nickname.java
+++ b/src/main/java/buncheoleasy/user/domain/Nickname.java
@@ -1,0 +1,46 @@
+package buncheoleasy.user.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record Nickname(String value) {
+
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[가-힣a-zA-Z0-9]+$");
+    private static final int MAX_LENGTH = 20;
+
+    public Nickname {
+        validateValue(value);
+    }
+
+    public static Nickname of(String value) {
+        return new Nickname(value);
+    }
+
+    private void validateValue(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.USER_NICKNAME_REQUIRED);
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new BusinessException(ErrorCode.USER_NICKNAME_LENGTH_INVALID);
+        }
+        if (!NICKNAME_REGEX.matcher(value).matches()) {
+            throw new BusinessException(ErrorCode.USER_NICKNAME_FORMAT_INVALID);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Nickname nickname = (Nickname) o;
+        return Objects.equals(this.value, nickname.value);
+    }
+
+}

--- a/src/main/java/buncheoleasy/user/domain/PhoneNumber.java
+++ b/src/main/java/buncheoleasy/user/domain/PhoneNumber.java
@@ -1,0 +1,47 @@
+package buncheoleasy.user.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record PhoneNumber(String value) {
+
+    private static final Pattern PHONE_NUMBER_REGEX = Pattern.compile("^01[0-9]+$");
+    private static final int MIN_LENGTH = 10;
+    private static final int MAX_LENGTH = 11;
+
+    public PhoneNumber {
+        validateValue(value);
+    }
+
+    public static PhoneNumber of(String value) {
+        return new PhoneNumber(value);
+    }
+
+    private void validateValue(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.USER_PHONE_NUMBER_REQUIRED);
+        }
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new BusinessException(ErrorCode.USER_PHONE_NUMBER_LENGTH_INVALID);
+        }
+        if (!PHONE_NUMBER_REGEX.matcher(value).matches()) {
+            throw new BusinessException(ErrorCode.USER_PHONE_NUMBER_FORMAT_INVALID);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PhoneNumber phoneNumber = (PhoneNumber) o;
+        return Objects.equals(this.value, phoneNumber.value);
+    }
+
+}

--- a/src/main/java/buncheoleasy/user/domain/SocialInfo.java
+++ b/src/main/java/buncheoleasy/user/domain/SocialInfo.java
@@ -1,0 +1,57 @@
+package buncheoleasy.user.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record SocialInfo(SocialProvider provider, String providerId) {
+
+    private static final Pattern PROVIDER_ID_REGEX = Pattern.compile("^[a-zA-Z0-9_-]+$");
+    private static final int MAX_LENGTH = 100;
+
+    public SocialInfo {
+        validateProviderId(providerId);
+    }
+
+    public static SocialInfo of(final String providerValue, final String providerId) {
+        SocialProvider provider = SocialProvider.from(providerValue);
+        return new SocialInfo(provider, providerId);
+    }
+
+    private void validateProviderId(final String providerId) {
+        if (providerId == null || providerId.isBlank()) {
+            throw new BusinessException(ErrorCode.USER_SOCIAL_ID_REQUIRED);
+        }
+        if (providerId.length() > MAX_LENGTH) {
+            throw new BusinessException(ErrorCode.USER_SOCIAL_ID_LENGTH_INVALID);
+        }
+        if (!PROVIDER_ID_REGEX.matcher(providerId).matches()) {
+            throw new BusinessException(ErrorCode.USER_SOCIAL_ID_FORMAT_INVALID);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SocialInfo socialInfo = (SocialInfo) o;
+
+        if (provider != socialInfo.provider) {
+            return false;
+        }
+        return Objects.equals(providerId, socialInfo.providerId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = provider != null ? provider.hashCode() : 0;
+        result = 31 * result + (providerId != null ? providerId.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/buncheoleasy/user/domain/SocialProvider.java
+++ b/src/main/java/buncheoleasy/user/domain/SocialProvider.java
@@ -1,0 +1,27 @@
+package buncheoleasy.user.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialProvider {
+
+    KAKAO("kakao");
+
+    private final String value;
+
+    public static SocialProvider from(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.PROVIDER_REQUIRED);
+        }
+        for (SocialProvider provider : values()) {
+            if (provider.value.equals(value)) {
+                return provider;
+            }
+        }
+        throw new BusinessException(ErrorCode.PROVIDER_NOT_FOUND);
+    }
+}

--- a/src/main/java/buncheoleasy/user/domain/User.java
+++ b/src/main/java/buncheoleasy/user/domain/User.java
@@ -1,0 +1,70 @@
+package buncheoleasy.user.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class User {
+
+    private static final String NICKNAME_PREFIX = "Guest";
+    private static final int RANDOM_SUFFIX_LENGTH = 10;
+
+    private Long id;
+    private final SocialInfo socialInfo;
+    private final Email email;
+    private Nickname nickname;
+    private PhoneNumber phoneNumber;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public User(final Long id, final String provider, final String providerId,
+                final String nickname, final String email, final String phoneNumber,
+                final LocalDateTime createdAt, final LocalDateTime updatedAt,
+                final LocalDateTime deletedAt) {
+        this.id = id;
+        this.socialInfo = SocialInfo.of(provider, providerId);
+        this.nickname = Nickname.of(nickname);
+        this.email = Email.of(email);
+        this.phoneNumber = phoneNumber != null ? new PhoneNumber(phoneNumber) : null;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public static User create(final String provider, final String providerId,
+                              final String email) {
+        return new User(provider, providerId, email);
+    }
+
+    private User(final String provider, final String providerId, final String email) {
+        this.socialInfo = SocialInfo.of(provider, providerId);
+        this.email = Email.of(email);
+        this.nickname = Nickname.of(generateRandomNickname());
+    }
+
+    private String generateRandomNickname() {
+        String cleanUuid = UUID.randomUUID().toString().replace("-", "");
+        String uniqueSuffix = cleanUuid.substring(0, RANDOM_SUFFIX_LENGTH);
+        return NICKNAME_PREFIX + uniqueSuffix;
+    }
+
+    public void updatePhoneNumber(final String newValue) {
+        PhoneNumber newPhoneNumber = PhoneNumber.of(newValue);
+        if (phoneNumber != null && phoneNumber.equals(newPhoneNumber)) {
+            throw new BusinessException(ErrorCode.USER_PHONE_NUMBER_UNCHANGED);
+        }
+        this.phoneNumber = newPhoneNumber;
+    }
+
+    public void updateNickname(final String newValue) {
+        Nickname newNickname = Nickname.of(newValue);
+        if (nickname != null && nickname.equals(newNickname)) {
+            throw new BusinessException(ErrorCode.USER_NICKNAME_UNCHANGED);
+        }
+        this.nickname = newNickname;
+    }
+}

--- a/src/main/java/buncheoleasy/user/domain/UserRepository.java
+++ b/src/main/java/buncheoleasy/user/domain/UserRepository.java
@@ -1,0 +1,10 @@
+package buncheoleasy.user.domain;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    User save(User user);
+
+    Optional<User> findById(Long id);
+}

--- a/src/main/java/buncheoleasy/user/infrastructure/MybatisUserRepository.java
+++ b/src/main/java/buncheoleasy/user/infrastructure/MybatisUserRepository.java
@@ -1,0 +1,25 @@
+package buncheoleasy.user.infrastructure;
+
+import buncheoleasy.user.domain.User;
+import buncheoleasy.user.domain.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MybatisUserRepository implements UserRepository {
+
+    private final UserMapper userMapper;
+
+    @Override
+    public User save(User user) {
+        userMapper.insert(user);
+        return user;
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userMapper.findById(id);
+    }
+}

--- a/src/main/java/buncheoleasy/user/infrastructure/UserMapper.java
+++ b/src/main/java/buncheoleasy/user/infrastructure/UserMapper.java
@@ -1,0 +1,13 @@
+package buncheoleasy.user.infrastructure;
+
+import buncheoleasy.user.domain.User;
+import java.util.Optional;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserMapper {
+
+    void insert(User user);
+
+    Optional<User> findById(Long id);
+}

--- a/src/main/java/buncheoleasy/user/infrastructure/UserMapper.xml
+++ b/src/main/java/buncheoleasy/user/infrastructure/UserMapper.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="buncheoleasy.user.infrastructure.UserMapper">
+
+    <!-- User ResultMap -->
+    <resultMap id="userResultMap" type="User">
+        <constructor>
+            <idArg column="id" javaType="Long"/>
+            <arg column="provider" javaType="String"/>
+            <arg column="provider_id" javaType="String"/>
+            <arg column="nickname" javaType="String"/>
+            <arg column="email" javaType="String"/>
+            <arg column="phone_number" javaType="String"/>
+            <arg column="created_at" javaType="java.time.LocalDateTime"/>
+            <arg column="updated_at" javaType="java.time.LocalDateTime"/>
+            <arg column="deleted_at" javaType="java.time.LocalDateTime"/>
+        </constructor>
+    </resultMap>
+
+    <!-- 유저 저장 -->
+    <insert id="insert" parameterType="User"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO users (provider,
+                           provider_id,
+                           nickname,
+                           email,
+                           phone_number,
+                           created_at,
+                           updated_at)
+        VALUES (#{socialInfo.provider.value},
+                #{socialInfo.providerId},
+                #{nickname.value},
+                #{email.value},
+                #{phoneNumber.value},
+                NOW(),
+                NOW())
+    </insert>
+
+    <!-- ID로 유저 조회 -->
+    <select id="findById" resultMap="userResultMap">
+        SELECT id,
+               provider,
+               provider_id,
+               nickname,
+               email,
+               phone_number,
+               created_at,
+               updated_at,
+               deleted_at
+        FROM users
+        WHERE id = #{id}
+          AND deleted_at IS NULL
+    </select>
+
+</mapper>

--- a/src/main/java/buncheoleasy/user/presentation/UserController.java
+++ b/src/main/java/buncheoleasy/user/presentation/UserController.java
@@ -1,0 +1,15 @@
+package buncheoleasy.user.presentation;
+
+import buncheoleasy.user.application.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,31 @@
+-- users 테이블 생성
+CREATE TABLE IF NOT EXISTS users
+(
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    provider            VARCHAR(20)  NOT NULL COMMENT '소셜 로그인 제공자 (KAKAO, GOOGLE, APPLE …)',
+    provider_id         VARCHAR(100) NOT NULL COMMENT '소셜 제공자 고유 ID',
+    email               VARCHAR(320) NOT NULL COMMENT '소셜 계정 이메일',
+    nickname            VARCHAR(20)  NOT NULL COMMENT '닉네임',
+    phone_number        VARCHAR(15)  NULL COMMENT '연락처',
+    profile_completed   TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '프로필 설정 완료 여부',
+    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at          DATETIME     NULL COMMENT '회원탈퇴 soft delete',
+
+    -- 유니크 제약조건을 위한 가상 컬럼 (deleted_at이 NULL이면 값을 갖고, 유저가 탈퇴하면 NULL이 된다)
+    _active_provider    VARCHAR(20) GENERATED ALWAYS AS (IF(deleted_at IS NULL, provider, NULL)) VIRTUAL,
+    _active_provider_id VARCHAR(100) GENERATED ALWAYS AS (IF(deleted_at IS NULL, provider_id, NULL)) VIRTUAL,
+    _active_nickname    VARCHAR(20) GENERATED ALWAYS AS (IF(deleted_at IS NULL, nickname, NULL)) VIRTUAL,
+    _active_phone       VARCHAR(15) GENERATED ALWAYS AS (IF(deleted_at IS NULL, phone_number, NULL)) VIRTUAL,
+
+    PRIMARY KEY (id),
+
+    UNIQUE INDEX uq_users_active_social_account (_active_provider, _active_provider_id),
+    UNIQUE INDEX uq_users_active_nickname (_active_nickname),
+    UNIQUE INDEX uq_users_active_phone (_active_phone),
+
+    INDEX idx_users_provider_id (provider_id),
+    INDEX idx_users_nickname (nickname)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/buncheoleasy/user/domain/UserTest.java
+++ b/src/test/java/buncheoleasy/user/domain/UserTest.java
@@ -1,0 +1,291 @@
+package buncheoleasy.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("User 엔티티 테스트")
+class UserTest {
+
+    @Nested
+    @DisplayName("User 생성 테스트")
+    class CreateUserTest {
+
+        @Test
+        void 유저_생성에_성공한다() {
+            // given
+            String provider = "kakao";
+            String providerId = "123456";
+            String email = "test@example.com";
+
+            // when
+            User user = User.create(provider, providerId, email);
+
+            // then
+            assertThat(user).isNotNull();
+            assertThat(user.getSocialInfo().provider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(user.getSocialInfo().providerId()).isEqualTo(providerId);
+            assertThat(user.getEmail().value()).isEqualTo(email);
+            assertThat(user.getNickname().value()).startsWith("Guest");
+            assertThat(user.getPhoneNumber()).isNull();
+            assertThat(user.getDeletedAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("ProviderId 검증 테스트")
+    class ValidateProviderIdTest {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void providerId가_null이거나_빈_값인_경우_예외가_발생한다(String providerId) {
+            // when & then
+            assertThatThrownBy(() -> User.create("kakao", providerId, "test@example.com"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_SOCIAL_ID_REQUIRED.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_SOCIAL_ID_REQUIRED);
+        }
+
+        @Test
+        void providerId가_최대_길이를_초과하면_예외가_발생한다() {
+            // given
+            String providerId = "a".repeat(101);
+
+            // when & then
+            assertThatThrownBy(() -> User.create("kakao", providerId, "test@example.com"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_SOCIAL_ID_LENGTH_INVALID.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_SOCIAL_ID_LENGTH_INVALID);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"kakao@123456", "kakao 123456", "kakao한글123", "google#123", "naver!456"})
+        void providerId_형식이_유효하지_않은_경우_예외가_발생한다(String providerId) {
+            // when & then
+            assertThatThrownBy(() -> User.create("kakao", providerId, "test@example.com"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_SOCIAL_ID_FORMAT_INVALID.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_SOCIAL_ID_FORMAT_INVALID);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"123456", "789012", "123", "test-user_123"})
+        void 올바른_형식의_providerId로_유저를_생성할_수_있다(String providerId) {
+            // when & then
+            assertThatCode(() -> User.create("kakao", providerId, "test@example.com"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("Email 검증 테스트")
+    class ValidateEmailTest {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void email이_null이거나_빈_값인_경우_예외가_발생한다(String email) {
+            // when & then
+            assertThatThrownBy(() -> User.create("kakao", "123456", email))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_EMAIL_REQUIRED.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_EMAIL_REQUIRED);
+        }
+
+        @Test
+        void email이_최대_길이를_초과하면_예외가_발생한다() {
+            // given
+            String email = "a".repeat(321);
+
+            // when & then
+            assertThatThrownBy(() -> User.create("kakao", "123456", email))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_EMAIL_LENGTH_INVALID.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_EMAIL_LENGTH_INVALID);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"testexample.com", "test@", "test@example", "test@example.c", "@example.com"})
+        void email_형식이_유효하지_않은_경우_예외가_발생한다(String email) {
+            // when & then
+            assertThatThrownBy(() -> User.create("kakao", "123456", email))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_EMAIL_FORMAT_INVALID.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_EMAIL_FORMAT_INVALID);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "test@example.com",
+                "test.user@example.co.kr",
+                "test+tag@sub.example.com",
+                "test_user123@example-domain.org"
+        })
+        void 올바른_형식의_email로_유저를_생성할_수_있다(String email) {
+            // when & then
+            assertThatCode(() -> User.create("kakao", "123456", email))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("PhoneNumber 검증 테스트")
+    class ValidatePhoneNumberTest {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void phoneNumber가_null이거나_빈_값인_경우_예외가_발생한다(String phoneNumber) {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when & then
+            assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_REQUIRED.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_PHONE_NUMBER_REQUIRED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"012345678", "012345678901"})
+        void phoneNumber가_길이가_유효하지_않으면_예외가_발생한다(String phoneNumber) {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when & then
+            assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_LENGTH_INVALID.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_PHONE_NUMBER_LENGTH_INVALID);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"0201234567", "1012345678", "00123456789", "a101234567", "0201234567a"})
+        void phoneNumber_형식이_유효하지_않은_경우_예외가_발생한다(String phoneNumber) {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when & then
+            assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_FORMAT_INVALID.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_PHONE_NUMBER_FORMAT_INVALID);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"01012345678", "01112345678", "01612345678", "01912345678", "0161234567"})
+        void 올바른_형식의_phoneNumber로_업데이트할_수_있다(String phoneNumber) {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when & then
+            assertThatCode(() -> user.updatePhoneNumber(phoneNumber))
+                    .doesNotThrowAnyException();
+
+            assertThat(user.getPhoneNumber().value()).isEqualTo(phoneNumber);
+        }
+
+        @Test
+        void 동일한_전화번호로_변경_시도시_예외가_발생한다() {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+            String phoneNumber = "01012345678";
+            user.updatePhoneNumber(phoneNumber);
+
+            // when & then
+            assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_UNCHANGED.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_PHONE_NUMBER_UNCHANGED);
+        }
+    }
+
+    @Nested
+    @DisplayName("Nickname 업데이트 테스트")
+    class UpdateNicknameTest {
+
+        @Test
+        void 올바른_형식의_nickname으로_업데이트할_수_있다() {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+            String newNickname = "새닉네임";
+
+            // when & then
+            assertThatCode(() -> user.updateNickname(newNickname))
+                    .doesNotThrowAnyException();
+
+            assertThat(user.getNickname().value()).isEqualTo(newNickname);
+        }
+
+        @Test
+        void 동일한_닉네임으로_변경_시도시_예외가_발생한다() {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+            String currentNickname = user.getNickname().value();
+
+            // when & then
+            assertThatThrownBy(() -> user.updateNickname(currentNickname))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_NICKNAME_UNCHANGED.getMessage())
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NICKNAME_UNCHANGED);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void nickname이_null이거나_빈_값인_경우_예외가_발생한다(String nickname) {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when & then
+            assertThatThrownBy(() -> user.updateNickname(nickname))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_NICKNAME_REQUIRED.getMessage());
+        }
+
+        @Test
+        void nickname이_최대_길이를_초과하면_예외가_발생한다() {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+            String nickname = "a".repeat(21);
+
+            // when & then
+            assertThatThrownBy(() -> user.updateNickname(nickname))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_NICKNAME_LENGTH_INVALID.getMessage());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"테스트@유저", "테스트 유저", "테스트_유저", "유저!", "nick#name"})
+        void nickname_형식이_유효하지_않은_경우_예외가_발생한다(String nickname) {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when & then
+            assertThatThrownBy(() -> user.updateNickname(nickname))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_NICKNAME_FORMAT_INVALID.getMessage());
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/infrastructure/UserMapperTest.java
+++ b/src/test/java/buncheoleasy/user/infrastructure/UserMapperTest.java
@@ -1,0 +1,76 @@
+package buncheoleasy.user.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import buncheoleasy.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+@MybatisTest
+@ActiveProfiles("test")
+@DisplayName("UserMapper 테스트")
+class UserMapperTest {
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Nested
+    @DisplayName("insert 테스트")
+    class InsertTest {
+
+        @Test
+        void User를_저장할_수_있다() {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+
+            // when
+            userMapper.insert(user);
+
+            // then
+            assertThat(user.getId()).isNotNull();
+            assertThat(user.getId()).isPositive();
+        }
+    }
+
+    @Nested
+    @DisplayName("findById 테스트")
+    class FindByIdTest {
+
+        @Test
+        void ID로_User를_조회할_수_있다() {
+            // given
+            User user = User.create("kakao", "123456", "test@example.com");
+            userMapper.insert(user);
+            Long userId = user.getId();
+
+            // when
+            User foundUser = userMapper.findById(userId).orElse(null);
+
+            // then
+            assertThat(foundUser).isNotNull();
+            assertThat(foundUser.getId()).isEqualTo(userId);
+            assertThat(foundUser.getSocialInfo().provider().getValue()).isEqualTo("kakao");
+            assertThat(foundUser.getSocialInfo().providerId()).isEqualTo("123456");
+            assertThat(foundUser.getEmail().value()).isEqualTo("test@example.com");
+            assertThat(foundUser.getNickname().value()).startsWith("Guest");
+            assertThat(foundUser.getPhoneNumber()).isNull();
+            assertThat(foundUser.getDeletedAt()).isNull();
+        }
+
+        @Test
+        void 존재하지_않는_ID로_조회하면_empty를_반환한다() {
+            // given
+            Long nonExistentId = 999999L;
+
+            // when
+            User foundUser = userMapper.findById(nonExistentId).orElse(null);
+
+            // then
+            assertThat(foundUser).isNull();
+        }
+    }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,33 @@
+-- Test H2 Database용 users 테이블 생성
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users
+(
+    id                 BIGINT       NOT NULL AUTO_INCREMENT,
+    provider           VARCHAR(20)  NOT NULL,
+    provider_id        VARCHAR(100) NOT NULL,
+    email              VARCHAR(320) NOT NULL,
+    nickname           VARCHAR(20)  NOT NULL,
+    phone_number       VARCHAR(15)  NULL,
+    profile_completed  BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at         TIMESTAMP    NULL,
+
+    -- 유니크 제약조건을 위한 가상 컬럼 (deleted_at이 NULL이면 값을 갖고, 유저가 탈퇴하면 NULL이 된다)
+    active_provider    VARCHAR(20) AS (CASE WHEN deleted_at IS NULL THEN provider END),
+    active_provider_id VARCHAR(100) AS (CASE WHEN deleted_at IS NULL THEN provider_id END),
+    active_nickname    VARCHAR(20) AS (CASE WHEN deleted_at IS NULL THEN nickname END),
+    active_phone       VARCHAR(15) AS (CASE WHEN deleted_at IS NULL THEN phone_number END),
+
+    PRIMARY KEY (id)
+);
+
+-- 가상 컬럼에 유니크 인덱스
+CREATE UNIQUE INDEX uq_users_active_social_account ON users (active_provider, active_provider_id);
+CREATE UNIQUE INDEX uq_users_active_nickname ON users (active_nickname);
+CREATE UNIQUE INDEX uq_users_active_phone ON users (active_phone);
+
+-- 일반 인덱스
+CREATE INDEX idx_users_provider_id ON users (provider_id);
+CREATE INDEX idx_users_nickname ON users (nickname);


### PR DESCRIPTION
## 관련 이슈
   - #4 
   - #5 

## 구현 내용
  User 도메인의 엔티티와 관련 계층을 구현했습니다.

  ### User 엔티티
  - 소셜 로그인 정보 (socialProvider, socialId)
  - 기본 정보 (nickname, email, phoneNumber)
  - 탈퇴 시 Soft Delete (deletedAt)
  - 생성 시 랜덤 닉네임 자동 부여 (Guest + UUID 10자)

  ### Value Object
  - **Email**: 이메일 형식 검증 (최대 320자)
  - **Nickname**: 한글/영문/숫자만 허용 (최대 20자)
  - **PhoneNumber**: 01X 형식 검증 (10-11자)
  - **SocialInfo**: 서로 관련있는 소셜 제공자와 ID를 하나로 캡슐화
 
###  최종 아키텍처
```

  ┌─────────────────────────────────────────┐
  │         Presentation Layer              │
  │           UserController                │
  └──────────────┬──────────────────────────┘
                 ↓
  ┌──────────────┴──────────────────────────┐
  │        Application Layer                │
  │           UserService                   │
  └──────────────┬──────────────────────────┘
                 ↓
  ┌──────────────┴──────────────────────────┐
  │          Domain Layer                   │
  │  User (Aggregate Root)                  │
  │  ├── SocialInfo (VO)                    │
  │  │   └── SocialProvider (enum)          │
  │  ├── Email (VO)                         │
  │  ├── Nickname (VO)                      │
  │  └── PhoneNumber (VO)                   │
  │                                         │
  │  UserRepository (interface)             │
  └──────────────┬──────────────────────────┘
                 ↑
  ┌──────────────┴──────────────────────────┐
  │      Infrastructure Layer               │
  │  MybatisUserRepository (implements)     │
  │  ├── UserMapper                         │
  │  └── UserMapper.xml (SQL)               │
  └─────────────────────────────────────────┘
```