### PR TITLE
[TEST] 유저 / 배송지 / 인증 모듈 테스트 추가

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Create Sonar Gradle File
         run: |
-          insert_string="plugins { id 'org.sonarqube' version '6.0.1.5171' }"
+          insert_string="plugins { id 'org.sonarqube' version '7.2.2.6593' }"
           if [ -f "build.gradle" ]; then
             echo "$insert_string" > temp.gradle
             cat build.gradle >> temp.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -54,6 +55,7 @@ dependencies {
 	// Spring Security
 	implementation "org.springframework.boot:spring-boot-starter-security"
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
@@ -64,6 +66,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
-tasks.named('test') {
+tasks.withType(Test).configureEach {
 	useJUnitPlatform()
+
+	doFirst {
+		def agent = configurations.testRuntimeClasspath.find {
+			it.name.contains("byte-buddy-agent")
+		}
+		if (agent != null) {
+			jvmArgs "-javaagent:${agent.absolutePath}"
+		}
+	}
 }

--- a/src/main/java/buncheoleasy/auth/infrastructure/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/buncheoleasy/auth/infrastructure/oauth/OAuth2LoginSuccessHandler.java
@@ -31,6 +31,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                                         Authentication authentication) throws IOException {
         OAuth2AuthenticationToken oauthToken = getAuthenticationToken(authentication);
         OAuth2UserProfile profile = getUserProfile(oauthToken);
+        validateSocialEmail(profile.email());
 
         TokenPair token = socialLoginService.login(
                 profile.provider().name(),
@@ -65,5 +66,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             }
         }
         throw new BusinessException(ErrorCode.AUTH_SOCIAL_PROVIDER_UNSUPPORTED);
+    }
+
+    private void validateSocialEmail(final String email) {
+        if (email == null || email.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_SOCIAL_EMAIL_REQUIRED);
+        }
     }
 }

--- a/src/main/java/buncheoleasy/global/config/SecurityConfig.java
+++ b/src/main/java/buncheoleasy/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_PATHS = {
             "/", "/index.html",
             "/favicon.ico",
+            "/error",
             "/v1/auth/reissue-token"
     };
 

--- a/src/main/java/buncheoleasy/user/application/ShippingAddressService.java
+++ b/src/main/java/buncheoleasy/user/application/ShippingAddressService.java
@@ -1,5 +1,8 @@
 package buncheoleasy.user.application;
 
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.UserDomainService;
 import buncheoleasy.user.domain.shipping.ShippingAddress;
 import buncheoleasy.user.domain.shipping.ShippingAddressDomainService;
 import buncheoleasy.user.dto.request.ShippingAddressRequest;
@@ -13,25 +16,36 @@ import org.springframework.stereotype.Service;
 public class ShippingAddressService {
 
     private final ShippingAddressDomainService shippingAddressDomainService;
+    private final UserDomainService userDomainService;
 
     public void registerShippingAddress(final Long userId, final ShippingAddressRequest request) {
+        validateUser(userId);
         shippingAddressDomainService.createShippingAddress(userId, request.shippingMethod(), request.storeName());
     }
 
     public void modifyShippingAddress(final Long userId, final Long addressId, final ShippingAddressRequest request) {
+        validateUser(userId);
         shippingAddressDomainService.updateShippingAddress(userId, addressId, request.shippingMethod(),
                 request.storeName());
     }
 
     public void removeShippingAddress(final Long userId, final Long addressId) {
+        validateUser(userId);
         shippingAddressDomainService.deleteShippingAddress(userId, addressId);
     }
 
     public List<ShippingAddressResponse> getUserShippingAddresses(final Long userId) {
+        validateUser(userId);
         return shippingAddressDomainService.getUserShippingAddresses(userId)
                 .stream()
                 .map(this::toResponse)
                 .toList();
+    }
+
+    private void validateUser(final Long userId) {
+        if(!userDomainService.isValidUser(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
     }
 
     private ShippingAddressResponse toResponse(final ShippingAddress shippingAddress) {

--- a/src/main/java/buncheoleasy/user/presentation/ShippingAddressController.java
+++ b/src/main/java/buncheoleasy/user/presentation/ShippingAddressController.java
@@ -25,10 +25,6 @@ public class ShippingAddressController {
 
     private final ShippingAddressService shippingAddressService;
 
-    /**
-     * TODO: user가 탈퇴 유저가 아닌지 검증이 필요함
-     */
-    
     @PostMapping
     public ResponseEntity<Void> registerShippingAddress(@AuthenticationPrincipal final Long userId,
                                                         @Valid @RequestBody final ShippingAddressRequest request) {

--- a/src/test/java/buncheoleasy/auth/application/SocialLoginServiceTest.java
+++ b/src/test/java/buncheoleasy/auth/application/SocialLoginServiceTest.java
@@ -1,0 +1,148 @@
+package buncheoleasy.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.auth.TokenPair;
+import buncheoleasy.auth.domain.RefreshTokenStore;
+import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.SocialInfo;
+import buncheoleasy.user.domain.User;
+import buncheoleasy.user.domain.UserDomainService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SocialLoginService 단위 테스트")
+class SocialLoginServiceTest {
+
+    @InjectMocks
+    private SocialLoginService socialLoginService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private UserDomainService userDomainService;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Nested
+    @DisplayName("login 테스트")
+    class LoginTest {
+
+        @Test
+        void 소셜_로그인_시_유저를_조회하고_토큰을_발급한다() {
+            // given
+            String provider = "KAKAO";
+            String providerId = "social_123";
+            String email = "test@example.com";
+            Long userId = 1L;
+            User user = new User(
+                    userId,
+                    provider,
+                    providerId,
+                    "테스트닉네임",
+                    email,
+                    null,
+                    false,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+            TokenPair expected = new TokenPair("access-token", "refresh-token");
+
+            given(userDomainService.getOrCreateBySocialLogin(any(SocialInfo.class), eq(email))).willReturn(user);
+            given(jwtTokenProvider.issueTokens(userId)).willReturn(expected);
+
+            // when
+            TokenPair result = socialLoginService.login(provider, providerId, email);
+
+            // then
+            ArgumentCaptor<SocialInfo> captor = ArgumentCaptor.forClass(SocialInfo.class);
+            then(userDomainService).should().getOrCreateBySocialLogin(captor.capture(), eq(email));
+            assertThat(captor.getValue().provider().name()).isEqualTo("KAKAO");
+            assertThat(captor.getValue().providerId()).isEqualTo(providerId);
+
+            then(jwtTokenProvider).should().issueTokens(userId);
+            assertThat(result).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("reissueTokens 테스트")
+    class ReissueTokensTest {
+
+        @Test
+        void 유효한_유저면_토큰을_재발급한다() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+            TokenPair expected = new TokenPair("new-access", "new-refresh");
+
+            given(jwtTokenProvider.parseUserIdFromRefreshToken(refreshToken)).willReturn(userId);
+            given(userDomainService.isValidUser(userId)).willReturn(true);
+            given(jwtTokenProvider.reissueTokens(userId, refreshToken)).willReturn(expected);
+
+            // when
+            TokenPair result = socialLoginService.reissueTokens(refreshToken);
+
+            // then
+            then(jwtTokenProvider).should().parseUserIdFromRefreshToken(refreshToken);
+            then(userDomainService).should().isValidUser(userId);
+            then(jwtTokenProvider).should().reissueTokens(userId, refreshToken);
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        void 유저가_유효하지_않으면_예외가_발생한다() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+
+            given(jwtTokenProvider.parseUserIdFromRefreshToken(refreshToken)).willReturn(userId);
+            given(userDomainService.isValidUser(userId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> socialLoginService.reissueTokens(refreshToken))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+
+            then(jwtTokenProvider).should().parseUserIdFromRefreshToken(refreshToken);
+            then(userDomainService).should().isValidUser(userId);
+            then(jwtTokenProvider).shouldHaveNoMoreInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("logout 테스트")
+    class LogoutTest {
+
+        @Test
+        void 로그아웃_시_리프레시_토큰을_삭제한다() {
+            // given
+            Long userId = 1L;
+
+            // when
+            socialLoginService.logout(userId);
+
+            // then
+            then(refreshTokenStore).should().delete(userId);
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/jwt/JwtAuthenticationEntryPointTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/jwt/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,92 @@
+package buncheoleasy.auth.infrastructure.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.auth.infrastructure.response.ErrorResponseWriter;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ProblemDetail;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthenticationEntryPoint 단위 테스트")
+class JwtAuthenticationEntryPointTest {
+
+    @Mock
+    private ErrorResponseWriter errorResponseWriter;
+
+    @Nested
+    @DisplayName("commence 테스트")
+    class CommenceTest {
+
+        @Test
+        void 요청_속성에_BusinessException이_있으면_해당_에러코드로_응답한다() throws Exception {
+            // given
+            JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint(errorResponseWriter);
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/users/me");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            request.setAttribute(
+                    JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE,
+                    new BusinessException(ErrorCode.AUTH_EXPIRED_TOKEN)
+            );
+
+            // when
+            entryPoint.commence(request, response, new BadCredentialsException("failed"));
+
+            // then
+            ArgumentCaptor<ProblemDetail> captor = ArgumentCaptor.forClass(ProblemDetail.class);
+            then(errorResponseWriter).should().write(eq(request), eq(response), captor.capture());
+            ProblemDetail problemDetail = captor.getValue();
+            assertThat(problemDetail.getStatus()).isEqualTo(ErrorCode.AUTH_EXPIRED_TOKEN.getHttpStatus().value());
+            assertThat(problemDetail.getProperties().get("code")).isEqualTo(ErrorCode.AUTH_EXPIRED_TOKEN.getCode());
+        }
+
+        @Test
+        void 요청_속성에_예외가_없으면_AUTH_INVALID_TOKEN으로_응답한다() throws Exception {
+            // given
+            JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint(errorResponseWriter);
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/users/me");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            entryPoint.commence(request, response, new BadCredentialsException("failed"));
+
+            // then
+            ArgumentCaptor<ProblemDetail> captor = ArgumentCaptor.forClass(ProblemDetail.class);
+            then(errorResponseWriter).should().write(eq(request), eq(response), captor.capture());
+            ProblemDetail problemDetail = captor.getValue();
+            assertThat(problemDetail.getStatus()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN.getHttpStatus().value());
+            assertThat(problemDetail.getProperties().get("code")).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN.getCode());
+        }
+
+        @Test
+        void 요청_속성에_BusinessException이_아닌_예외가_있어도_AUTH_INVALID_TOKEN으로_응답한다() throws Exception {
+            // given
+            JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint(errorResponseWriter);
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/users/me");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            request.setAttribute(JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE, new RuntimeException("unexpected"));
+
+            // when
+            entryPoint.commence(request, response, new BadCredentialsException("failed"));
+
+            // then
+            ArgumentCaptor<ProblemDetail> captor = ArgumentCaptor.forClass(ProblemDetail.class);
+            then(errorResponseWriter).should().write(eq(request), eq(response), captor.capture());
+            ProblemDetail problemDetail = captor.getValue();
+            assertThat(problemDetail.getStatus()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN.getHttpStatus().value());
+            assertThat(problemDetail.getProperties().get("code")).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN.getCode());
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,133 @@
+package buncheoleasy.auth.infrastructure.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthenticationFilter 단위 테스트")
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    @DisplayName("토큰 추출/인증 테스트")
+    class AuthenticationTest {
+
+        @Test
+        void Authorization_헤더가_없으면_인증없이_다음_필터로_진행한다() throws Exception {
+            // given
+            JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = new MockFilterChain();
+
+            // when
+            filter.doFilter(request, response, chain);
+
+            // then
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            assertThat(request.getAttribute(JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE)).isNull();
+        }
+
+        @Test
+        void 정상_Bearer_토큰이면_SecurityContext에_인증정보를_설정한다() throws Exception {
+            // given
+            JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer valid-token");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = new MockFilterChain();
+            given(jwtTokenProvider.parseUserIdFromAccessToken("valid-token")).willReturn(1L);
+
+            // when
+            filter.doFilter(request, response, chain);
+
+            // then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNotNull();
+            assertThat(authentication.getPrincipal()).isEqualTo(1L);
+            assertThat(request.getAttribute(JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE)).isNull();
+        }
+
+        @Test
+        void Bearer_형식이_아니면_예외를_요청_속성에_저장한다() throws Exception {
+            // given
+            JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Token invalid");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = new MockFilterChain();
+
+            // when
+            filter.doFilter(request, response, chain);
+
+            // then
+            Object attribute = request.getAttribute(JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE);
+            assertThat(attribute).isInstanceOf(BusinessException.class);
+            assertThat(((BusinessException) attribute).getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        void Bearer_접두사_뒤에_토큰이_비어있으면_예외를_요청_속성에_저장한다() throws Exception {
+            // given
+            JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer   ");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = new MockFilterChain();
+
+            // when
+            filter.doFilter(request, response, chain);
+
+            // then
+            Object attribute = request.getAttribute(JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE);
+            assertThat(attribute).isInstanceOf(BusinessException.class);
+            assertThat(((BusinessException) attribute).getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        void 토큰_파싱_중_예외가_발생하면_예외를_요청_속성에_저장한다() throws Exception {
+            // given
+            JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer expired-token");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = new MockFilterChain();
+            given(jwtTokenProvider.parseUserIdFromAccessToken("expired-token"))
+                    .willThrow(new BusinessException(ErrorCode.AUTH_EXPIRED_TOKEN));
+
+            // when
+            filter.doFilter(request, response, chain);
+
+            // then
+            Object attribute = request.getAttribute(JwtAuthenticationFilter.EXCEPTION_ATTRIBUTE);
+            assertThat(attribute).isInstanceOf(BusinessException.class);
+            assertThat(((BusinessException) attribute).getErrorCode()).isEqualTo(ErrorCode.AUTH_EXPIRED_TOKEN);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,159 @@
+package buncheoleasy.auth.infrastructure.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.auth.TokenPair;
+import buncheoleasy.auth.domain.RefreshTokenStore;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtTokenProvider 단위 테스트")
+class JwtTokenProviderTest {
+
+    private static final String ACCESS_SECRET = "test-access-secret-test-access-secret-test-access-secret";
+    private static final String REFRESH_SECRET = "test-refresh-secret-test-refresh-secret-test-refresh-secret";
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    private JwtTokenProvider createProvider(long accessExp, long refreshExp) {
+        return new JwtTokenProvider(ACCESS_SECRET, REFRESH_SECRET, accessExp, refreshExp, refreshTokenStore);
+    }
+
+    @Nested
+    @DisplayName("issueTokens/parse 테스트")
+    class IssueAndParseTest {
+
+        @Test
+        void 토큰을_발급하고_userId를_다시_파싱할_수_있다() {
+            // given
+            JwtTokenProvider provider = createProvider(3600, 604800);
+            Long userId = 1L;
+
+            // when
+            TokenPair tokenPair = provider.issueTokens(userId);
+
+            // then
+            assertThat(provider.parseUserIdFromAccessToken(tokenPair.accessToken())).isEqualTo(userId);
+            assertThat(provider.parseUserIdFromRefreshToken(tokenPair.refreshToken())).isEqualTo(userId);
+            then(refreshTokenStore).should().save(userId, tokenPair.refreshToken(), 604800);
+        }
+
+        @Test
+        void 잘못된_서명의_액세스_토큰이면_예외가_발생한다() {
+            // given
+            JwtTokenProvider provider = createProvider(3600, 604800);
+            SecretKey anotherKey = Keys.hmacShaKeyFor("another-secret-key-for-signature-123".getBytes(StandardCharsets.UTF_8));
+            String invalidSignedToken = Jwts.builder()
+                    .subject("1")
+                    .signWith(anotherKey)
+                    .compact();
+
+            // when & then
+            assertThatThrownBy(() -> provider.parseUserIdFromAccessToken(invalidSignedToken))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        @Test
+        void 잘못된_서명의_리프레시_토큰이면_예외가_발생한다() {
+            // given
+            JwtTokenProvider provider = createProvider(3600, 604800);
+            SecretKey anotherKey = Keys.hmacShaKeyFor("another-refresh-key-for-signature-123".getBytes(StandardCharsets.UTF_8));
+            String invalidSignedToken = Jwts.builder()
+                    .subject("1")
+                    .signWith(anotherKey)
+                    .compact();
+
+            // when & then
+            assertThatThrownBy(() -> provider.parseUserIdFromRefreshToken(invalidSignedToken))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        @Test
+        void 만료된_액세스_토큰이면_예외가_발생한다() {
+            // given
+            JwtTokenProvider provider = createProvider(-1, 604800);
+            String expiredToken = provider.createAccessToken(1L);
+
+            // when & then
+            assertThatThrownBy(() -> provider.parseUserIdFromAccessToken(expiredToken))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_EXPIRED_TOKEN);
+        }
+
+        @Test
+        void 만료된_리프레시_토큰이면_예외가_발생한다() {
+            // given
+            JwtTokenProvider provider = createProvider(3600, -1);
+            String expiredToken = provider.createRefreshToken(1L);
+
+            // when & then
+            assertThatThrownBy(() -> provider.parseUserIdFromRefreshToken(expiredToken))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_EXPIRED_TOKEN);
+        }
+
+        @Test
+        void subject가_숫자가_아니면_예외가_발생한다() {
+            // given
+            JwtTokenProvider provider = createProvider(3600, 604800);
+            SecretKey refreshKey = Keys.hmacShaKeyFor(REFRESH_SECRET.getBytes(StandardCharsets.UTF_8));
+            String token = Jwts.builder()
+                    .subject("not-number")
+                    .signWith(refreshKey)
+                    .compact();
+
+            // when & then
+            assertThatThrownBy(() -> provider.parseUserIdFromRefreshToken(token))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("reissueTokens 테스트")
+    class ReissueTokensTest {
+
+        @Test
+        void 기존_토큰을_검증하고_삭제한_뒤_새_토큰을_발급한다() {
+            // given
+            JwtTokenProvider provider = createProvider(3600, 604800);
+            Long userId = 1L;
+            String oldRefreshToken = "old-refresh-token";
+
+            // when
+            TokenPair tokenPair = provider.reissueTokens(userId, oldRefreshToken);
+
+            // then
+            assertThat(provider.parseUserIdFromAccessToken(tokenPair.accessToken())).isEqualTo(userId);
+            assertThat(provider.parseUserIdFromRefreshToken(tokenPair.refreshToken())).isEqualTo(userId);
+
+            InOrder inOrder = Mockito.inOrder(refreshTokenStore);
+            inOrder.verify(refreshTokenStore).verify(userId, oldRefreshToken);
+            inOrder.verify(refreshTokenStore).delete(userId);
+            inOrder.verify(refreshTokenStore).save(userId, tokenPair.refreshToken(), 604800);
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/oauth/KakaoOidcUserProfileExtractorTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/oauth/KakaoOidcUserProfileExtractorTest.java
@@ -1,0 +1,80 @@
+package buncheoleasy.auth.infrastructure.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.SocialProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("KakaoOidcUserProfileExtractor 단위 테스트")
+class KakaoOidcUserProfileExtractorTest {
+
+    @Mock
+    private OidcUser oidcUser;
+
+    @Mock
+    private OAuth2User oauth2User;
+
+    @Nested
+    @DisplayName("supports 테스트")
+    class SupportsTest {
+
+        @Test
+        void registrationId가_kakao이면_true를_반환한다() {
+            KakaoOidcUserProfileExtractor extractor = new KakaoOidcUserProfileExtractor();
+
+            assertThat(extractor.supports("kakao")).isTrue();
+        }
+
+        @Test
+        void registrationId가_kakao가_아니면_false를_반환한다() {
+            KakaoOidcUserProfileExtractor extractor = new KakaoOidcUserProfileExtractor();
+
+            assertThat(extractor.supports("google")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("extract 테스트")
+    class ExtractTest {
+
+        @Test
+        void OidcUser에서_프로필을_추출한다() {
+            // given
+            KakaoOidcUserProfileExtractor extractor = new KakaoOidcUserProfileExtractor();
+            given(oidcUser.getSubject()).willReturn("provider-id");
+            given(oidcUser.getEmail()).willReturn("test@example.com");
+
+            // when
+            OAuth2UserProfile profile = extractor.extract(oidcUser);
+
+            // then
+            assertThat(profile.provider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(profile.providerId()).isEqualTo("provider-id");
+            assertThat(profile.email()).isEqualTo("test@example.com");
+        }
+
+        @Test
+        void OidcUser가_아니면_예외가_발생한다() {
+            // given
+            KakaoOidcUserProfileExtractor extractor = new KakaoOidcUserProfileExtractor();
+
+            // when & then
+            assertThatThrownBy(() -> extractor.extract(oauth2User))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_SOCIAL_PROVIDER_UNSUPPORTED);
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/oauth/OAuth2LoginFailureHandlerTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/oauth/OAuth2LoginFailureHandlerTest.java
@@ -1,0 +1,45 @@
+package buncheoleasy.auth.infrastructure.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.auth.infrastructure.response.ErrorResponseWriter;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ProblemDetail;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OAuth2LoginFailureHandler 단위 테스트")
+class OAuth2LoginFailureHandlerTest {
+
+    @Mock
+    private ErrorResponseWriter errorResponseWriter;
+
+    @Test
+    void 로그인_실패시_표준_에러코드를_응답한다() throws Exception {
+        // given
+        OAuth2LoginFailureHandler handler = new OAuth2LoginFailureHandler(errorResponseWriter);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login/oauth2/code/kakao");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AuthenticationException exception = new AuthenticationException("failed") {};
+
+        // when
+        handler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        ArgumentCaptor<ProblemDetail> captor = ArgumentCaptor.forClass(ProblemDetail.class);
+        then(errorResponseWriter).should().write(org.mockito.ArgumentMatchers.eq(request), org.mockito.ArgumentMatchers.eq(response), captor.capture());
+
+        ProblemDetail problemDetail = captor.getValue();
+        assertThat(problemDetail.getStatus()).isEqualTo(ErrorCode.AUTH_OAUTH2_LOGIN_FAILED.getHttpStatus().value());
+        assertThat(problemDetail.getProperties().get("code")).isEqualTo(ErrorCode.AUTH_OAUTH2_LOGIN_FAILED.getCode());
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -1,0 +1,158 @@
+package buncheoleasy.auth.infrastructure.oauth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.auth.TokenPair;
+import buncheoleasy.auth.application.SocialLoginService;
+import buncheoleasy.auth.infrastructure.response.TokenResponseWriter;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OAuth2LoginSuccessHandler 단위 테스트")
+class OAuth2LoginSuccessHandlerTest {
+
+    @Mock
+    private OAuth2UserProfileExtractor profileExtractor;
+
+    @Mock
+    private SocialLoginService socialLoginService;
+
+    @Mock
+    private TokenResponseWriter tokenResponseWriter;
+
+    @Mock
+    private OAuth2User principal;
+
+    @Nested
+    @DisplayName("onAuthenticationSuccess 테스트")
+    class OnAuthenticationSuccessTest {
+
+        @Test
+        void 프로필을_추출하고_로그인한_뒤_토큰을_응답으로_작성한다() throws Exception {
+            // given
+            OAuth2LoginSuccessHandler handler = new OAuth2LoginSuccessHandler(
+                    List.of(profileExtractor), socialLoginService, tokenResponseWriter
+            );
+            OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+                    principal,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER")),
+                    "kakao"
+            );
+            OAuth2UserProfile profile = new OAuth2UserProfile(
+                    buncheoleasy.user.domain.SocialProvider.KAKAO,
+                    "provider-id",
+                    "test@example.com"
+            );
+            TokenPair tokenPair = new TokenPair("access", "refresh");
+
+            given(profileExtractor.supports("kakao")).willReturn(true);
+            given(profileExtractor.extract(principal)).willReturn(profile);
+            given(socialLoginService.login("KAKAO", "provider-id", "test@example.com")).willReturn(tokenPair);
+
+            // when
+            handler.onAuthenticationSuccess(new MockHttpServletRequest(), new MockHttpServletResponse(), authentication);
+
+            // then
+            then(socialLoginService).should().login("KAKAO", "provider-id", "test@example.com");
+            then(tokenResponseWriter).should().write(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(tokenPair));
+        }
+
+        @Test
+        void OAuth2AuthenticationToken이_아니면_예외가_발생한다() {
+            // given
+            OAuth2LoginSuccessHandler handler = new OAuth2LoginSuccessHandler(
+                    List.of(profileExtractor), socialLoginService, tokenResponseWriter
+            );
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken("user", null);
+
+            // when & then
+            assertThatThrownBy(() -> handler.onAuthenticationSuccess(
+                    new MockHttpServletRequest(),
+                    new MockHttpServletResponse(),
+                    authentication
+            ))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_UNSUPPORTED_AUTHENTICATION);
+        }
+
+        @Test
+        void 프로필_추출_중_런타임_예외가_발생하면_지원하지_않는_제공자로_처리한다() {
+            // given
+            OAuth2LoginSuccessHandler handler = new OAuth2LoginSuccessHandler(
+                    List.of(profileExtractor), socialLoginService, tokenResponseWriter
+            );
+            OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+                    principal,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER")),
+                    "kakao"
+            );
+
+            given(profileExtractor.supports("kakao")).willReturn(true);
+            given(profileExtractor.extract(principal)).willThrow(new RuntimeException("broken principal"));
+
+            // when & then
+            assertThatThrownBy(() -> handler.onAuthenticationSuccess(
+                    new MockHttpServletRequest(),
+                    new MockHttpServletResponse(),
+                    authentication
+            ))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_SOCIAL_PROVIDER_UNSUPPORTED);
+        }
+
+        @Test
+        void 소셜_이메일이_없으면_예외가_발생한다() {
+            // given
+            OAuth2LoginSuccessHandler handler = new OAuth2LoginSuccessHandler(
+                    List.of(profileExtractor), socialLoginService, tokenResponseWriter
+            );
+            OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+                    principal,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER")),
+                    "kakao"
+            );
+            OAuth2UserProfile profile = new OAuth2UserProfile(
+                    buncheoleasy.user.domain.SocialProvider.KAKAO,
+                    "provider-id",
+                    null
+            );
+
+            given(profileExtractor.supports("kakao")).willReturn(true);
+            given(profileExtractor.extract(principal)).willReturn(profile);
+
+            // when & then
+            assertThatThrownBy(() -> handler.onAuthenticationSuccess(
+                    new MockHttpServletRequest(),
+                    new MockHttpServletResponse(),
+                    authentication
+            ))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_SOCIAL_EMAIL_REQUIRED);
+
+            then(socialLoginService).should(never()).login(org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+            then(tokenResponseWriter).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/redis/RedisRefreshTokenStoreTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/redis/RedisRefreshTokenStoreTest.java
@@ -1,0 +1,103 @@
+package buncheoleasy.auth.infrastructure.redis;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisRefreshTokenStore 단위 테스트")
+class RedisRefreshTokenStoreTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Nested
+    @DisplayName("save/delete 테스트")
+    class SaveDeleteTest {
+
+        @Test
+        void save는_RT_prefix_키로_토큰을_저장한다() {
+            // given
+            RedisRefreshTokenStore store = new RedisRefreshTokenStore(redisTemplate);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // when
+            store.save(1L, "refresh-token", 3600);
+
+            // then
+            then(valueOperations).should().set("RT:1", "refresh-token", 3600, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void delete는_RT_prefix_키를_삭제한다() {
+            // given
+            RedisRefreshTokenStore store = new RedisRefreshTokenStore(redisTemplate);
+
+            // when
+            store.delete(1L);
+
+            // then
+            then(redisTemplate).should().delete("RT:1");
+        }
+    }
+
+    @Nested
+    @DisplayName("verify 테스트")
+    class VerifyTest {
+
+        @Test
+        void 저장된_토큰과_일치하면_통과한다() {
+            // given
+            RedisRefreshTokenStore store = new RedisRefreshTokenStore(redisTemplate);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("RT:1")).willReturn("token");
+
+            // when & then
+            assertThatCode(() -> store.verify(1L, "token")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void 저장된_토큰이_없으면_예외가_발생한다() {
+            // given
+            RedisRefreshTokenStore store = new RedisRefreshTokenStore(redisTemplate);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("RT:1")).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> store.verify(1L, "token"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        @Test
+        void 저장된_토큰과_다르면_예외가_발생한다() {
+            // given
+            RedisRefreshTokenStore store = new RedisRefreshTokenStore(redisTemplate);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("RT:1")).willReturn("another-token");
+
+            // when & then
+            assertThatThrownBy(() -> store.verify(1L, "token"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/response/ErrorResponseWriterTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/response/ErrorResponseWriterTest.java
@@ -1,0 +1,40 @@
+package buncheoleasy.auth.infrastructure.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
+
+@DisplayName("ErrorResponseWriter 단위 테스트")
+class ErrorResponseWriterTest {
+
+    private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter(new ObjectMapper());
+
+    @Test
+    void ProblemDetail_응답에_instance_URI를_추가하여_JSON으로_작성한다() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ProblemDetail problemDetail = ErrorCode.AUTH_INVALID_TOKEN.toProblemDetail();
+
+        // when
+        errorResponseWriter.write(request, response, problemDetail);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(response.getCharacterEncoding()).isEqualTo("UTF-8");
+
+        String body = response.getContentAsString();
+        assertThat(body)
+                .contains("\"instance\":\"/v1/users/me\"")
+                .contains(ErrorCode.AUTH_INVALID_TOKEN.getCode())
+                .contains(ErrorCode.AUTH_INVALID_TOKEN.getMessage());
+    }
+}

--- a/src/test/java/buncheoleasy/auth/infrastructure/response/TokenResponseWriterTest.java
+++ b/src/test/java/buncheoleasy/auth/infrastructure/response/TokenResponseWriterTest.java
@@ -1,0 +1,34 @@
+package buncheoleasy.auth.infrastructure.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import buncheoleasy.auth.TokenPair;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
+
+@DisplayName("TokenResponseWriter 단위 테스트")
+class TokenResponseWriterTest {
+
+    private final TokenResponseWriter tokenResponseWriter = new TokenResponseWriter(new ObjectMapper());
+
+    @Test
+    void 토큰_응답을_JSON으로_작성한다() throws Exception {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        TokenPair tokenPair = new TokenPair("access-token", "refresh-token");
+
+        // when
+        tokenResponseWriter.write(response, tokenPair);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(response.getCharacterEncoding()).isEqualTo("UTF-8");
+        assertThat(response.getContentAsString())
+                .contains("\"accessToken\":\"access-token\"")
+                .contains("\"refreshToken\":\"refresh-token\"");
+    }
+}

--- a/src/test/java/buncheoleasy/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/buncheoleasy/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,103 @@
+package buncheoleasy.auth.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import buncheoleasy.auth.TokenPair;
+import buncheoleasy.auth.application.SocialLoginService;
+import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("AuthController 테스트")
+class AuthControllerTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SocialLoginService socialLoginService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private RequestPostProcessor mockAuth() {
+        return (MockHttpServletRequest request) -> {
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(USER_ID, null, Collections.emptyList())
+            );
+            return request;
+        };
+    }
+
+    @Test
+    void 토큰_재발급_요청이_성공하면_200을_반환한다() throws Exception {
+        given(socialLoginService.reissueTokens("valid-refresh"))
+                .willReturn(new TokenPair("new-access", "new-refresh"));
+
+        mockMvc.perform(post("/v1/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"valid-refresh\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("new-access"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh"));
+    }
+
+    @Test
+    void 토큰_재발급_요청_검증에_실패하면_400과_표준_에러코드를_반환한다() throws Exception {
+        mockMvc.perform(post("/v1/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.INVALID_INPUT_VALUE.getCode())));
+    }
+
+    @Test
+    void 토큰_재발급_중_BusinessException이_발생하면_해당_HTTP_상태코드로_매핑된다() throws Exception {
+        given(socialLoginService.reissueTokens("invalid-refresh"))
+                .willThrow(new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+
+        mockMvc.perform(post("/v1/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"invalid-refresh\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.AUTH_INVALID_TOKEN.getCode())));
+    }
+
+    @Test
+    void 로그아웃_요청이_성공하면_204를_반환한다() throws Exception {
+        mockMvc.perform(post("/v1/auth/logout").with(mockAuth()))
+                .andExpect(status().isNoContent());
+
+        then(socialLoginService).should().logout(USER_ID);
+    }
+}

--- a/src/test/java/buncheoleasy/auth/presentation/AuthControllerWebMvcTest.java
+++ b/src/test/java/buncheoleasy/auth/presentation/AuthControllerWebMvcTest.java
@@ -1,0 +1,103 @@
+package buncheoleasy.auth.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import buncheoleasy.auth.TokenPair;
+import buncheoleasy.auth.application.SocialLoginService;
+import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("AuthController WebMvc 테스트")
+class AuthControllerWebMvcTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SocialLoginService socialLoginService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private RequestPostProcessor mockAuth() {
+        return (MockHttpServletRequest request) -> {
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(USER_ID, null, Collections.emptyList())
+            );
+            return request;
+        };
+    }
+
+    @Test
+    void 토큰_재발급_요청이_성공하면_200을_반환한다() throws Exception {
+        given(socialLoginService.reissueTokens("valid-refresh"))
+                .willReturn(new TokenPair("new-access", "new-refresh"));
+
+        mockMvc.perform(post("/v1/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"valid-refresh\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("new-access"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh"));
+    }
+
+    @Test
+    void 토큰_재발급_요청_검증에_실패하면_400과_표준_에러코드를_반환한다() throws Exception {
+        mockMvc.perform(post("/v1/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.INVALID_INPUT_VALUE.getCode())));
+    }
+
+    @Test
+    void 토큰_재발급_중_BusinessException이_발생하면_해당_HTTP_상태코드로_매핑된다() throws Exception {
+        given(socialLoginService.reissueTokens("invalid-refresh"))
+                .willThrow(new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+
+        mockMvc.perform(post("/v1/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"invalid-refresh\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.AUTH_INVALID_TOKEN.getCode())));
+    }
+
+    @Test
+    void 로그아웃_요청이_성공하면_204를_반환한다() throws Exception {
+        mockMvc.perform(post("/v1/auth/logout").with(mockAuth()))
+                .andExpect(status().isNoContent());
+
+        then(socialLoginService).should().logout(USER_ID);
+    }
+}

--- a/src/test/java/buncheoleasy/user/application/ShippingAddressServiceTest.java
+++ b/src/test/java/buncheoleasy/user/application/ShippingAddressServiceTest.java
@@ -1,9 +1,13 @@
 package buncheoleasy.user.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.UserDomainService;
 import buncheoleasy.user.domain.shipping.ShippingAddress;
 import buncheoleasy.user.domain.shipping.ShippingAddressDomainService;
 import buncheoleasy.user.domain.shipping.ShippingMethod;
@@ -29,6 +33,9 @@ class ShippingAddressServiceTest {
     @Mock
     private ShippingAddressDomainService shippingAddressDomainService;
 
+    @Mock
+    private UserDomainService userDomainService;
+
     private ShippingAddress savedAddress(Long id, Long userId, String method, String storeName) {
         return new ShippingAddress(id, userId, ShippingMethod.of(method), storeName,
                 LocalDateTime.now(), LocalDateTime.now());
@@ -43,6 +50,7 @@ class ShippingAddressServiceTest {
             // given
             Long userId = 1L;
             ShippingAddressRequest request = new ShippingAddressRequest("GS25_HALF", "GS25 강남역점");
+            given(userDomainService.isValidUser(userId)).willReturn(true);
 
             // when
             shippingAddressService.registerShippingAddress(userId, request);
@@ -50,6 +58,22 @@ class ShippingAddressServiceTest {
             // then
             then(shippingAddressDomainService).should()
                     .createShippingAddress(userId, "GS25_HALF", "GS25 강남역점");
+        }
+
+        @Test
+        void 유효하지_않은_유저면_예외가_발생하고_등록하지_않는다() {
+            // given
+            Long userId = 1L;
+            ShippingAddressRequest request = new ShippingAddressRequest("GS25_HALF", "GS25 강남역점");
+            given(userDomainService.isValidUser(userId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressService.registerShippingAddress(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            then(shippingAddressDomainService).shouldHaveNoInteractions();
         }
     }
 
@@ -63,6 +87,7 @@ class ShippingAddressServiceTest {
             Long userId = 1L;
             Long addressId = 10L;
             ShippingAddressRequest request = new ShippingAddressRequest("CU_HALF", "CU 홍대입구점");
+            given(userDomainService.isValidUser(userId)).willReturn(true);
 
             // when
             shippingAddressService.modifyShippingAddress(userId, addressId, request);
@@ -70,6 +95,23 @@ class ShippingAddressServiceTest {
             // then
             then(shippingAddressDomainService).should()
                     .updateShippingAddress(userId, addressId, "CU_HALF", "CU 홍대입구점");
+        }
+
+        @Test
+        void 유효하지_않은_유저면_예외가_발생하고_수정하지_않는다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+            ShippingAddressRequest request = new ShippingAddressRequest("CU_HALF", "CU 홍대입구점");
+            given(userDomainService.isValidUser(userId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressService.modifyShippingAddress(userId, addressId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            then(shippingAddressDomainService).shouldHaveNoInteractions();
         }
     }
 
@@ -82,6 +124,7 @@ class ShippingAddressServiceTest {
             // given
             Long userId = 1L;
             Long addressId = 10L;
+            given(userDomainService.isValidUser(userId)).willReturn(true);
 
             // when
             shippingAddressService.removeShippingAddress(userId, addressId);
@@ -89,6 +132,22 @@ class ShippingAddressServiceTest {
             // then
             then(shippingAddressDomainService).should()
                     .deleteShippingAddress(userId, addressId);
+        }
+
+        @Test
+        void 유효하지_않은_유저면_예외가_발생하고_삭제하지_않는다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+            given(userDomainService.isValidUser(userId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressService.removeShippingAddress(userId, addressId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            then(shippingAddressDomainService).shouldHaveNoInteractions();
         }
     }
 
@@ -105,6 +164,7 @@ class ShippingAddressServiceTest {
                     savedAddress(2L, userId, "CU_HALF", "CU 홍대입구점")
             );
             given(shippingAddressDomainService.getUserShippingAddresses(userId)).willReturn(addresses);
+            given(userDomainService.isValidUser(userId)).willReturn(true);
 
             // when
             List<ShippingAddressResponse> responses = shippingAddressService.getUserShippingAddresses(userId);
@@ -124,12 +184,28 @@ class ShippingAddressServiceTest {
             // given
             Long userId = 1L;
             given(shippingAddressDomainService.getUserShippingAddresses(userId)).willReturn(List.of());
+            given(userDomainService.isValidUser(userId)).willReturn(true);
 
             // when
             List<ShippingAddressResponse> responses = shippingAddressService.getUserShippingAddresses(userId);
 
             // then
             assertThat(responses).isEmpty();
+        }
+
+        @Test
+        void 유효하지_않은_유저면_예외가_발생하고_조회하지_않는다() {
+            // given
+            Long userId = 1L;
+            given(userDomainService.isValidUser(userId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressService.getUserShippingAddresses(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            then(shippingAddressDomainService).shouldHaveNoInteractions();
         }
     }
 }

--- a/src/test/java/buncheoleasy/user/application/ShippingAddressServiceTest.java
+++ b/src/test/java/buncheoleasy/user/application/ShippingAddressServiceTest.java
@@ -1,0 +1,135 @@
+package buncheoleasy.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.user.domain.shipping.ShippingAddress;
+import buncheoleasy.user.domain.shipping.ShippingAddressDomainService;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
+import buncheoleasy.user.dto.request.ShippingAddressRequest;
+import buncheoleasy.user.dto.response.ShippingAddressResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingAddressService 단위 테스트")
+class ShippingAddressServiceTest {
+
+    @InjectMocks
+    private ShippingAddressService shippingAddressService;
+
+    @Mock
+    private ShippingAddressDomainService shippingAddressDomainService;
+
+    private ShippingAddress savedAddress(Long id, Long userId, String method, String storeName) {
+        return new ShippingAddress(id, userId, ShippingMethod.of(method), storeName,
+                LocalDateTime.now(), LocalDateTime.now());
+    }
+
+    @Nested
+    @DisplayName("배송지 등록 테스트")
+    class RegisterShippingAddressTest {
+
+        @Test
+        void 배송지_등록을_도메인_서비스에_위임한다() {
+            // given
+            Long userId = 1L;
+            ShippingAddressRequest request = new ShippingAddressRequest("GS25_HALF", "GS25 강남역점");
+
+            // when
+            shippingAddressService.registerShippingAddress(userId, request);
+
+            // then
+            then(shippingAddressDomainService).should()
+                    .createShippingAddress(userId, "GS25_HALF", "GS25 강남역점");
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 수정 테스트")
+    class ModifyShippingAddressTest {
+
+        @Test
+        void 배송지_수정을_도메인_서비스에_위임한다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+            ShippingAddressRequest request = new ShippingAddressRequest("CU_HALF", "CU 홍대입구점");
+
+            // when
+            shippingAddressService.modifyShippingAddress(userId, addressId, request);
+
+            // then
+            then(shippingAddressDomainService).should()
+                    .updateShippingAddress(userId, addressId, "CU_HALF", "CU 홍대입구점");
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 삭제 테스트")
+    class RemoveShippingAddressTest {
+
+        @Test
+        void 배송지_삭제를_도메인_서비스에_위임한다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+
+            // when
+            shippingAddressService.removeShippingAddress(userId, addressId);
+
+            // then
+            then(shippingAddressDomainService).should()
+                    .deleteShippingAddress(userId, addressId);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 조회 테스트")
+    class GetUserShippingAddressesTest {
+
+        @Test
+        void 배송지_목록을_response로_변환하여_반환한다() {
+            // given
+            Long userId = 1L;
+            List<ShippingAddress> addresses = List.of(
+                    savedAddress(1L, userId, "GS25_HALF", "GS25 강남역점"),
+                    savedAddress(2L, userId, "CU_HALF", "CU 홍대입구점")
+            );
+            given(shippingAddressDomainService.getUserShippingAddresses(userId)).willReturn(addresses);
+
+            // when
+            List<ShippingAddressResponse> responses = shippingAddressService.getUserShippingAddresses(userId);
+
+            // then
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).id()).isEqualTo(1L);
+            assertThat(responses.get(0).shippingMethod()).isEqualTo("GS25_HALF");
+            assertThat(responses.get(0).storeName()).isEqualTo("GS25 강남역점");
+            assertThat(responses.get(1).id()).isEqualTo(2L);
+            assertThat(responses.get(1).shippingMethod()).isEqualTo("CU_HALF");
+            assertThat(responses.get(1).storeName()).isEqualTo("CU 홍대입구점");
+        }
+
+        @Test
+        void 배송지가_없으면_빈_리스트를_반환한다() {
+            // given
+            Long userId = 1L;
+            given(shippingAddressDomainService.getUserShippingAddresses(userId)).willReturn(List.of());
+
+            // when
+            List<ShippingAddressResponse> responses = shippingAddressService.getUserShippingAddresses(userId);
+
+            // then
+            assertThat(responses).isEmpty();
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/application/UserServiceTest.java
+++ b/src/test/java/buncheoleasy/user/application/UserServiceTest.java
@@ -1,0 +1,124 @@
+package buncheoleasy.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+
+import buncheoleasy.auth.domain.RefreshTokenStore;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.User;
+import buncheoleasy.user.domain.UserDomainService;
+import buncheoleasy.user.dto.request.UpdateUserProfileRequest;
+import buncheoleasy.user.dto.response.UserProfileResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserDomainService userDomainService;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Nested
+    @DisplayName("회원 탈퇴 테스트")
+    class WithdrawTest {
+
+        @Test
+        void 정상적으로_탈퇴하고_리프레시_토큰을_삭제한다() {
+            // given
+            Long userId = 1L;
+
+            // when
+            userService.withdraw(userId);
+
+            // then
+            then(userDomainService).should().withdraw(userId);
+            then(refreshTokenStore).should().delete(userId);
+        }
+
+        @Test
+        void 리프레시_토큰_삭제_실패해도_탈퇴는_정상_처리된다() {
+            // given
+            Long userId = 1L;
+            doThrow(new RuntimeException("Redis 연결 실패"))
+                    .when(refreshTokenStore).delete(userId);
+
+            // when & then: 예외가 전파되지 않아야 함
+            userService.withdraw(userId);
+
+            then(userDomainService).should().withdraw(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("User 프로필 업데이트 테스트")
+    class UpdateProfileTest {
+
+        @Test
+        void 프로필을_정상적으로_업데이트한다() {
+            // given
+            Long userId = 1L;
+            UpdateUserProfileRequest request = new UpdateUserProfileRequest("새닉네임", "01012345678");
+
+            // when
+            userService.updateProfile(userId, request);
+
+            // then
+            then(userDomainService).should().updateProfile(userId, "새닉네임", "01012345678");
+        }
+    }
+
+    @Nested
+    @DisplayName("User 프로필 조회 테스트")
+    class GetUserProfileTest {
+
+        @Test
+        void 프로필이_완료된_유저의_정보를_조회할_수_있다() {
+            // given
+            Long userId = 1L;
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            user.updatePhoneNumber("01012345678");
+            user.updateNickname("테스트닉");
+            given(userDomainService.getUser(userId)).willReturn(user);
+
+            // when
+            UserProfileResponse response = userService.getUserProfile(userId);
+
+            // then
+            assertThat(response.provider()).isEqualTo("KAKAO");
+            assertThat(response.email()).isEqualTo("test@example.com");
+            assertThat(response.nickname()).isEqualTo("테스트닉");
+            assertThat(response.phoneNumber()).isEqualTo("01012345678");
+        }
+
+        @Test
+        void 프로필이_완료되지_않은_유저를_조회하면_예외가_발생한다() {
+            // given
+            Long userId = 1L;
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            // profileCompleted = false (전화번호 미설정)
+            given(userDomainService.getUser(userId)).willReturn(user);
+
+            // when & then
+            assertThatThrownBy(() -> userService.getUserProfile(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_PROFILE_IS_NOT_COMPLETE);
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/domain/UserDomainServiceTest.java
+++ b/src/test/java/buncheoleasy/user/domain/UserDomainServiceTest.java
@@ -1,0 +1,208 @@
+package buncheoleasy.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserDomainService 단위 테스트")
+class UserDomainServiceTest {
+
+    @InjectMocks
+    private UserDomainService userDomainService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Nested
+    @DisplayName("소셜 로그인 테스트")
+    class GetOrCreateBySocialLoginTest {
+
+        @Test
+        void 기존_유저가_있으면_해당_유저를_반환한다() {
+            // given
+            SocialInfo socialInfo = SocialInfo.of("KAKAO", "123456");
+            User existingUser = User.create("KAKAO", "123456", "test@example.com");
+            given(userRepository.findBySocialInfo(socialInfo)).willReturn(Optional.of(existingUser));
+
+            // when
+            User result = userDomainService.getOrCreateBySocialLogin(socialInfo, "test@example.com");
+
+            // then
+            assertThat(result).isEqualTo(existingUser);
+            then(userRepository).should(never()).save(any());
+        }
+
+        @Test
+        void 기존_유저가_없으면_새_유저를_생성하고_저장한다() {
+            // given
+            SocialInfo socialInfo = SocialInfo.of("KAKAO", "new_user");
+            String email = "new@example.com";
+            given(userRepository.findBySocialInfo(socialInfo)).willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            User result = userDomainService.getOrCreateBySocialLogin(socialInfo, email);
+
+            // then
+            assertThat(result.getEmail().value()).isEqualTo(email);
+            assertThat(result.getSocialInfo().provider()).isEqualTo(SocialProvider.KAKAO);
+            then(userRepository).should().save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("유효한 User 검사 테스트")
+    class IsValidUserTest {
+
+        @Test
+        void 유저가_존재하면_true를_반환한다() {
+            // given
+            given(userRepository.existsById(1L)).willReturn(true);
+
+            // when
+            boolean result = userDomainService.isValidUser(1L);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 유저가_존재하지_않으면_false를_반환한다() {
+            // given
+            given(userRepository.existsById(999L)).willReturn(false);
+
+            // when
+            boolean result = userDomainService.isValidUser(999L);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("User 조회 테스트")
+    class GetUserTest {
+
+        @Test
+        void 존재하는_유저를_조회할_수_있다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+            // when
+            User result = userDomainService.getUser(1L);
+
+            // then
+            assertThat(result).isEqualTo(user);
+        }
+
+        @Test
+        void 존재하지_않는_유저를_조회하면_예외가_발생한다() {
+            // given
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userDomainService.getUser(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 테스트")
+    class WithdrawTest {
+
+        @Test
+        void 회원_탈퇴_시_withdraw_후_repository에_반영된다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+            // when
+            userDomainService.withdraw(1L);
+
+            // then
+            assertThat(user.getDeletedAt()).isNotNull();
+            then(userRepository).should().withdraw(user);
+        }
+
+        @Test
+        void 존재하지_않는_회원이_탈퇴하면_예외가_발생한다() {
+            // given
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userDomainService.withdraw(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("User 프로필 업데이트 테스트")
+    class UpdateProfileTest {
+
+        @Test
+        void 닉네임_중복이_없으면_프로필을_업데이트한다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.existsByNicknameExcludingId("새닉네임", 1L)).willReturn(false);
+
+            // when
+            userDomainService.updateProfile(1L, "새닉네임", "01012345678");
+
+            // then
+            assertThat(user.getNickname().value()).isEqualTo("새닉네임");
+            assertThat(user.getPhoneNumber().value()).isEqualTo("01012345678");
+            then(userRepository).should().update(user);
+        }
+
+        @Test
+        void 닉네임이_중복되면_예외가_발생한다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userRepository.existsByNicknameExcludingId("중복닉네임", 1L)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userDomainService.updateProfile(1L, "중복닉네임", "01012345678"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NICKNAME_DUPLICATE);
+
+            then(userRepository).should(never()).update(any());
+        }
+
+        @Test
+        void 존재하지_않는_유저의_프로필을_업데이트하면_예외가_발생한다() {
+            // given
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userDomainService.updateProfile(999L, "새닉네임", "01012345678"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            then(userRepository).should(never()).update(any());
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/domain/UserTest.java
+++ b/src/test/java/buncheoleasy/user/domain/UserTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@DisplayName("User 엔티티 테스트")
+@DisplayName("User 도메인 테스트")
 class UserTest {
 
     @Nested
@@ -31,7 +31,6 @@ class UserTest {
             User user = User.create(provider, providerId, email);
 
             // then
-            assertThat(user).isNotNull();
             assertThat(user.getSocialInfo().provider()).isEqualTo(SocialProvider.KAKAO);
             assertThat(user.getSocialInfo().providerId()).isEqualTo(providerId);
             assertThat(user.getEmail().value()).isEqualTo(email);
@@ -52,7 +51,6 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> User.create("KAKAO", providerId, "test@example.com"))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_SOCIAL_ID_REQUIRED.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_SOCIAL_ID_REQUIRED);
         }
@@ -65,24 +63,22 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> User.create("KAKAO", providerId, "test@example.com"))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_SOCIAL_ID_LENGTH_INVALID.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_SOCIAL_ID_LENGTH_INVALID);
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"kakao@123456", "kakao 123456", "kakao한글123", "google#123", "naver!456"})
+        @ValueSource(strings = {"@123456", " 123456", "한글123", "1 23"})
         void providerId_형식이_유효하지_않은_경우_예외가_발생한다(String providerId) {
             // when & then
             assertThatThrownBy(() -> User.create("KAKAO", providerId, "test@example.com"))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_SOCIAL_ID_FORMAT_INVALID.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_SOCIAL_ID_FORMAT_INVALID);
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"123456", "789012", "123", "test-user_123"})
+        @ValueSource(strings = {"123456", "789012", "aa123", "test-user_123"})
         void 올바른_형식의_providerId로_유저를_생성할_수_있다(String providerId) {
             // when & then
             assertThatCode(() -> User.create("KAKAO", providerId, "test@example.com"))
@@ -101,7 +97,6 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> User.create("KAKAO", "123456", email))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_EMAIL_REQUIRED.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_EMAIL_REQUIRED);
         }
@@ -114,7 +109,6 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> User.create("KAKAO", "123456", email))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_EMAIL_LENGTH_INVALID.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_EMAIL_LENGTH_INVALID);
         }
@@ -125,7 +119,6 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> User.create("KAKAO", "123456", email))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_EMAIL_FORMAT_INVALID.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_EMAIL_FORMAT_INVALID);
         }
@@ -151,14 +144,13 @@ class UserTest {
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = {"   "})
-        void phoneNumber가_null이거나_빈_값인_경우_예외가_발생한다(String phoneNumber) {
+        void phoneNumber를_null혹은_빈_값으로_변경할_경우_예외가_발생한다(String phoneNumber) {
             // given
             User user = User.create("KAKAO", "123456", "test@example.com");
 
             // when & then
             assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_REQUIRED.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_PHONE_NUMBER_REQUIRED);
         }
@@ -172,7 +164,6 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_LENGTH_INVALID.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_PHONE_NUMBER_LENGTH_INVALID);
         }
@@ -186,7 +177,6 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> user.updatePhoneNumber(phoneNumber))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_PHONE_NUMBER_FORMAT_INVALID.getMessage())
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_PHONE_NUMBER_FORMAT_INVALID);
         }
@@ -202,6 +192,41 @@ class UserTest {
                     .doesNotThrowAnyException();
 
             assertThat(user.getPhoneNumber().value()).isEqualTo(phoneNumber);
+        }
+    }
+
+    @Nested
+    @DisplayName("PhoneNumber 최초 설정 시 profileCompleted 테스트")
+    class ProfileCompletedTest {
+
+        @Test
+        void 전화번호를_최초_설정하면_profileCompleted가_true가_된다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            assertThat(user.getPhoneNumber()).isNull();
+            assertThat(user.isProfileCompleted()).isFalse();
+
+            // when
+            user.updatePhoneNumber("01012345678");
+
+            // then
+            assertThat(user.isProfileCompleted()).isTrue();
+        }
+
+        @Test
+        void 전화번호가_이미_설정된_경우_업데이트해도_profileCompleted는_유지된다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            user.updatePhoneNumber("01012345678");
+            assertThat(user.isProfileCompleted()).isTrue();
+            String newPhoneNumber = "01098765432";
+
+            // when
+            user.updatePhoneNumber(newPhoneNumber);
+
+            // then
+            assertThat(user.isProfileCompleted()).isTrue();
+            assertThat(user.getPhoneNumber().value()).isEqualTo(newPhoneNumber);
         }
     }
 
@@ -232,7 +257,8 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> user.updateNickname(nickname))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_NICKNAME_REQUIRED.getMessage());
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NICKNAME_REQUIRED);
         }
 
         @Test
@@ -244,7 +270,8 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> user.updateNickname(nickname))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_NICKNAME_LENGTH_INVALID.getMessage());
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NICKNAME_LENGTH_INVALID);
         }
 
         @ParameterizedTest
@@ -256,7 +283,26 @@ class UserTest {
             // when & then
             assertThatThrownBy(() -> user.updateNickname(nickname))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.USER_NICKNAME_FORMAT_INVALID.getMessage());
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NICKNAME_FORMAT_INVALID);
+        }
+    }
+
+    @Nested
+    @DisplayName("User 탈퇴 테스트")
+    class WithdrawTest {
+
+        @Test
+        void 탈퇴_시_deletedAt이_설정된다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            assertThat(user.getDeletedAt()).isNull();
+
+            // when
+            user.withdraw();
+
+            // then
+            assertThat(user.getDeletedAt()).isNotNull();
         }
     }
 }

--- a/src/test/java/buncheoleasy/user/domain/shipping/ShippingAddressDomainServiceTest.java
+++ b/src/test/java/buncheoleasy/user/domain/shipping/ShippingAddressDomainServiceTest.java
@@ -1,0 +1,257 @@
+package buncheoleasy.user.domain.shipping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingAddressDomainService 단위 테스트")
+class ShippingAddressDomainServiceTest {
+
+    @InjectMocks
+    private ShippingAddressDomainService shippingAddressDomainService;
+
+    @Mock
+    private ShippingAddressRepository shippingAddressRepository;
+
+    private ShippingAddress savedAddress(Long id, Long userId, String method, String storeName) {
+        return new ShippingAddress(id, userId, ShippingMethod.of(method), storeName,
+                LocalDateTime.now(), LocalDateTime.now());
+    }
+
+    @Nested
+    @DisplayName("배송지 생성 테스트")
+    class CreateShippingAddressTest {
+
+        @Test
+        void 배송지를_정상적으로_생성할_수_있다() {
+            // given
+            Long userId = 1L;
+            given(shippingAddressRepository.countByUserId(userId)).willReturn(0);
+            given(shippingAddressRepository.existsByUserIdAndShippingMethodAndStoreName(userId, "GS25_HALF", "GS25 강남역점"))
+                    .willReturn(false);
+            given(shippingAddressRepository.save(any(ShippingAddress.class)))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            ShippingAddress result = shippingAddressDomainService.createShippingAddress(
+                    userId, "GS25_HALF", "GS25 강남역점");
+
+            // then
+            assertThat(result.getShippingMethod()).isEqualTo(ShippingMethod.GS25_HALF);
+            assertThat(result.getStoreName()).isEqualTo("GS25 강남역점");
+            then(shippingAddressRepository).should().save(any(ShippingAddress.class));
+        }
+
+        @Test
+        void 배송지가_10개이면_예외가_발생한다() {
+            // given
+            Long userId = 1L;
+            given(shippingAddressRepository.countByUserId(userId)).willReturn(10);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressDomainService.createShippingAddress(
+                    userId, "GS25_HALF", "GS25 강남역점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_LIMIT_EXCEEDED);
+
+            then(shippingAddressRepository).should(never()).save(any());
+        }
+
+        @Test
+        void 중복된_배송지이면_예외가_발생한다() {
+            // given
+            Long userId = 1L;
+            given(shippingAddressRepository.countByUserId(userId)).willReturn(3);
+            given(shippingAddressRepository.existsByUserIdAndShippingMethodAndStoreName(userId, "GS25_HALF", "GS25 강남역점"))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressDomainService.createShippingAddress(
+                    userId, "GS25_HALF", "GS25 강남역점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_DUPLICATE);
+
+            then(shippingAddressRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 수정 테스트")
+    class UpdateShippingAddressTest {
+
+        @Test
+        void 배송지를_정상적으로_수정할_수_있다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+            ShippingAddress address = savedAddress(addressId, userId, "GS25_HALF", "GS25 강남역점");
+            given(shippingAddressRepository.findById(addressId)).willReturn(Optional.of(address));
+            given(shippingAddressRepository.existsByUserIdAndShippingMethodAndStoreName(userId, "CU_HALF", "CU 홍대입구점"))
+                    .willReturn(false);
+
+            // when
+            shippingAddressDomainService.updateShippingAddress(userId, addressId, "CU_HALF", "CU 홍대입구점");
+
+            // then
+            assertThat(address.getShippingMethod()).isEqualTo(ShippingMethod.CU_HALF);
+            assertThat(address.getStoreName()).isEqualTo("CU 홍대입구점");
+            then(shippingAddressRepository).should().update(address);
+        }
+
+        @Test
+        void 존재하지_않는_배송지를_수정하면_예외가_발생한다() {
+            // given
+            given(shippingAddressRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressDomainService.updateShippingAddress(
+                    1L, 999L, "CU_HALF", "CU 홍대입구점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_NOT_FOUND);
+
+            then(shippingAddressRepository).should(never()).update(any());
+        }
+
+        @Test
+        void 다른_유저의_배송지를_수정하면_예외가_발생한다() {
+            // given
+            Long addressId = 10L;
+            ShippingAddress address = savedAddress(addressId, 2L, "GS25_HALF", "GS25 강남역점");
+            given(shippingAddressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+            // when & then: userId=1L이지만 배송지 소유자는 2L
+            assertThatThrownBy(() -> shippingAddressDomainService.updateShippingAddress(
+                    1L, addressId, "CU_HALF", "CU 홍대입구점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_FORBIDDEN);
+
+            then(shippingAddressRepository).should(never()).update(any());
+        }
+
+        @Test
+        void 다른_내용으로_수정할_때_이미_존재하는_배송지이면_예외가_발생한다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+            ShippingAddress address = savedAddress(addressId, userId, "GS25_HALF", "GS25 강남역점");
+            given(shippingAddressRepository.findById(addressId)).willReturn(Optional.of(address));
+            given(shippingAddressRepository.existsByUserIdAndShippingMethodAndStoreName(userId, "CU_HALF", "CU 홍대입구점"))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressDomainService.updateShippingAddress(
+                    userId, addressId, "CU_HALF", "CU 홍대입구점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_DUPLICATE);
+
+            then(shippingAddressRepository).should(never()).update(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 삭제 테스트")
+    class DeleteShippingAddressTest {
+
+        @Test
+        void 본인_배송지를_삭제할_수_있다() {
+            // given
+            Long userId = 1L;
+            Long addressId = 10L;
+            ShippingAddress address = savedAddress(addressId, userId, "GS25_HALF", "GS25 강남역점");
+            given(shippingAddressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+            // when
+            shippingAddressDomainService.deleteShippingAddress(userId, addressId);
+
+            // then
+            then(shippingAddressRepository).should().delete(addressId);
+        }
+
+        @Test
+        void 존재하지_않는_배송지를_삭제하면_예외가_발생한다() {
+            // given
+            given(shippingAddressRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressDomainService.deleteShippingAddress(1L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_NOT_FOUND);
+
+            then(shippingAddressRepository).should(never()).delete(any());
+        }
+
+        @Test
+        void 다른_유저의_배송지를_삭제하면_예외가_발생한다() {
+            // given
+            Long addressId = 10L;
+            ShippingAddress address = savedAddress(addressId, 2L, "GS25_HALF", "GS25 강남역점");
+            given(shippingAddressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+            // when & then
+            assertThatThrownBy(() -> shippingAddressDomainService.deleteShippingAddress(1L, addressId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_ADDRESS_FORBIDDEN);
+
+            then(shippingAddressRepository).should(never()).delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 조회 테스트")
+    class GetUserShippingAddressesTest {
+
+        @Test
+        void 유저의_배송지_목록을_조회할_수_있다() {
+            // given
+            Long userId = 1L;
+            List<ShippingAddress> expected = List.of(
+                    savedAddress(1L, userId, "GS25_HALF", "GS25 강남역점"),
+                    savedAddress(2L, userId, "CU_HALF", "CU 홍대입구점")
+            );
+            given(shippingAddressRepository.getUserShippingAddresses(userId)).willReturn(expected);
+
+            // when
+            List<ShippingAddress> result = shippingAddressDomainService.getUserShippingAddresses(userId);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        void 배송지가_없으면_빈_리스트를_반환한다() {
+            // given
+            Long userId = 1L;
+            given(shippingAddressRepository.getUserShippingAddresses(userId)).willReturn(List.of());
+
+            // when
+            List<ShippingAddress> result = shippingAddressDomainService.getUserShippingAddresses(userId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/domain/shipping/ShippingAddressTest.java
+++ b/src/test/java/buncheoleasy/user/domain/shipping/ShippingAddressTest.java
@@ -119,7 +119,7 @@ class ShippingAddressTest {
         }
 
         @Test
-        void 상점명이_다르면_false를_반환한다() {
+        void 지점명이_다르면_false를_반환한다() {
             // given
             ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
 

--- a/src/test/java/buncheoleasy/user/domain/shipping/ShippingAddressTest.java
+++ b/src/test/java/buncheoleasy/user/domain/shipping/ShippingAddressTest.java
@@ -1,0 +1,154 @@
+package buncheoleasy.user.domain.shipping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ShippingAddress 도메인 테스트")
+class ShippingAddressTest {
+
+    @Nested
+    @DisplayName("ShippingAddress 생성 테스트")
+    class CreateTest {
+
+        @Test
+        void GS25_반값택배_배송지를_생성할_수_있다() {
+            // given
+            Long userId = 1L;
+
+            // when
+            ShippingAddress address = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+
+            // then
+            assertThat(address.getUserId()).isEqualTo(userId);
+            assertThat(address.getShippingMethod()).isEqualTo(ShippingMethod.GS25_HALF);
+            assertThat(address.getStoreName()).isEqualTo("GS25 강남역점");
+            assertThat(address.getId()).isNull();
+        }
+
+        @Test
+        void CU_반값택배_배송지를_생성할_수_있다() {
+            // given
+            Long userId = 1L;
+
+            // when
+            ShippingAddress address = ShippingAddress.create(userId, "CU_HALF", "CU 홍대입구점");
+
+            // then
+            assertThat(address.getShippingMethod()).isEqualTo(ShippingMethod.CU_HALF);
+            assertThat(address.getStoreName()).isEqualTo("CU 홍대입구점");
+        }
+
+        @Test
+        void 유효하지_않은_배송방법으로_생성하면_예외가_발생한다() {
+            assertThatThrownBy(() -> ShippingAddress.create(1L, "INVALID", "GS25 강남역점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_METHOD_FORMAT_INVALID);
+        }
+    }
+
+    @Nested
+    @DisplayName("ShippingAddress 수정 테스트")
+    class UpdateTest {
+
+        @Test
+        void 배송방법과_지점명을_변경할_수_있다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when
+            address.update("CU_HALF", "CU 홍대입구점");
+
+            // then
+            assertThat(address.getShippingMethod()).isEqualTo(ShippingMethod.CU_HALF);
+            assertThat(address.getStoreName()).isEqualTo("CU 홍대입구점");
+        }
+
+        @Test
+        void 동일한_배송방법으로도_수정할_수_있다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when
+            address.update("GS25_HALF", "GS25 신촌역점");
+
+            // then
+            assertThat(address.getShippingMethod()).isEqualTo(ShippingMethod.GS25_HALF);
+            assertThat(address.getStoreName()).isEqualTo("GS25 신촌역점");
+        }
+
+        @Test
+        void 유효하지_않은_배송방법으로_수정하면_예외가_발생한다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when & then
+            assertThatThrownBy(() -> address.update("INVALID_METHOD", "GS25 강남역점"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_METHOD_FORMAT_INVALID);
+        }
+    }
+
+    @Nested
+    @DisplayName("isSameAddress 테스트")
+    class IsSameAddressTest {
+
+        @Test
+        void 동일한_배송방법과_지점명이면_true를_반환한다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when & then
+            assertThat(address.isSameAddress("GS25_HALF", "GS25 강남역점")).isTrue();
+        }
+
+        @Test
+        void 배송방법이_다르면_false를_반환한다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when & then
+            assertThat(address.isSameAddress("CU_HALF", "GS25 강남역점")).isFalse();
+        }
+
+        @Test
+        void 상점명이_다르면_false를_반환한다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when & then
+            assertThat(address.isSameAddress("GS25_HALF", "GS25 신촌역점")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwnedBy 테스트")
+    class IsOwnedByTest {
+
+        @Test
+        void 소유자_ID와_일치하면_true를_반환한다() {
+            // given
+            Long userId = 1L;
+            ShippingAddress address = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+
+            // when & then
+            assertThat(address.isOwnedBy(userId)).isTrue();
+        }
+
+        @Test
+        void 소유자_ID와_일치하지_않으면_false를_반환한다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(1L, "GS25_HALF", "GS25 강남역점");
+
+            // when & then
+            assertThat(address.isOwnedBy(2L)).isFalse();
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/domain/shipping/ShippingMethodTest.java
+++ b/src/test/java/buncheoleasy/user/domain/shipping/ShippingMethodTest.java
@@ -1,0 +1,42 @@
+package buncheoleasy.user.domain.shipping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("ShippingMethod 테스트")
+class ShippingMethodTest {
+
+    @Nested
+    @DisplayName("ShippingMethod 생성 테스트")
+    class OfTest {
+
+        @Test
+        void GS25_반값택배로_ShippingMethod를_생성할_수_있다() {
+            ShippingMethod method = ShippingMethod.of("GS25_HALF");
+            assertThat(method).isEqualTo(ShippingMethod.GS25_HALF);
+        }
+
+        @Test
+        void CU_반값택배로_ShippingMethod를_생성할_수_있다() {
+            ShippingMethod method = ShippingMethod.of("CU_HALF");
+            assertThat(method).isEqualTo(ShippingMethod.CU_HALF);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"UNKNOWN", "gs25_half", "CU_HALF_PRICE", "GS25", "cu_half", "GS25HALF"})
+        void 유효하지_않은_배송방법이면_예외가_발생한다(String name) {
+            assertThatThrownBy(() -> ShippingMethod.of(name))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SHIPPING_METHOD_FORMAT_INVALID);
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/infrastructure/UserMapperTest.java
+++ b/src/test/java/buncheoleasy/user/infrastructure/UserMapperTest.java
@@ -20,7 +20,7 @@ class UserMapperTest {
     private UserMapper userMapper;
 
     @Nested
-    @DisplayName("insert 테스트")
+    @DisplayName("유저 저장 테스트")
     class InsertTest {
 
         @Test
@@ -38,7 +38,7 @@ class UserMapperTest {
     }
 
     @Nested
-    @DisplayName("findById 테스트")
+    @DisplayName("ID로 유저 조회 테스트")
     class FindByIdTest {
 
         @Test
@@ -76,7 +76,7 @@ class UserMapperTest {
     }
 
     @Nested
-    @DisplayName("findBySocialInfo 테스트")
+    @DisplayName("소셜 정보로 유저 조회 테스트")
     class FindBySocialInfoTest {
 
         @Test
@@ -102,6 +102,144 @@ class UserMapperTest {
 
             // then
             assertThat(foundUser).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 존재 여부 확인 테스트")
+    class ExistsByIdTest {
+
+        @Test
+        void 존재하는_ID면_true를_반환한다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            userMapper.insert(user);
+
+            // when
+            boolean exists = userMapper.existsById(user.getId());
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void 존재하지_않는_ID면_false를_반환한다() {
+            // when
+            boolean exists = userMapper.existsById(999999L);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("중복 닉네임 검사 테스트")
+    class ExistsByNicknameExcludingIdTest {
+
+        @Test
+        void 다른_유저가_동일한_닉네임을_사용하면_true를_반환한다() {
+            // given
+            User user1 = User.create("KAKAO", "user1", "user1@example.com");
+            userMapper.insert(user1);
+            user1.updateNickname("닉네임충돌");
+            userMapper.update(user1);
+
+            User user2 = User.create("KAKAO", "user2", "user2@example.com");
+            userMapper.insert(user2);
+
+            // when: user2의 ID를 제외하고 "닉네임충돌" 닉네임 존재 여부 확인
+            boolean exists = userMapper.existsByNicknameExcludingId("닉네임충돌", user2.getId());
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void 자신의_ID를_제외하면_false를_반환한다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            userMapper.insert(user);
+            user.updateNickname("내닉네임");
+            userMapper.update(user);
+
+            // when: 자신의 ID를 제외하고 확인
+            boolean exists = userMapper.existsByNicknameExcludingId("내닉네임", user.getId());
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void 해당_닉네임이_없으면_false를_반환한다() {
+            // when
+            boolean exists = userMapper.existsByNicknameExcludingId("없는닉네임", 999999L);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 수정 테스트")
+    class UpdateTest {
+
+        @Test
+        void User_정보를_업데이트할_수_있다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            userMapper.insert(user);
+            String newNickname = "새닉네임";
+            String newPhoneNumber = "01012345678";
+            user.updateNickname(newNickname);
+            user.updatePhoneNumber(newPhoneNumber);
+
+            // when
+            userMapper.update(user);
+
+            // then
+            User updated = userMapper.findById(user.getId()).orElseThrow();
+            assertThat(updated.getNickname().value()).isEqualTo(newNickname);
+            assertThat(updated.getPhoneNumber().value()).isEqualTo(newPhoneNumber);
+            assertThat(updated.isProfileCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 테스트")
+    class UpdateDeletedAtTest {
+
+        @Test
+        void 회원_탈퇴_시_deletedAt이_설정되고_조회되지_않는다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            userMapper.insert(user);
+            Long userId = user.getId();
+
+            user.withdraw();
+
+            // when
+            userMapper.updateDeletedAt(userId, user.getDeletedAt());
+
+            // then
+            User found = userMapper.findById(userId).orElse(null);
+            assertThat(found).isNull();
+        }
+
+        @Test
+        void 탈퇴_후_existsById도_false를_반환한다() {
+            // given
+            User user = User.create("KAKAO", "123456", "test@example.com");
+            userMapper.insert(user);
+            Long userId = user.getId();
+
+            user.withdraw();
+            userMapper.updateDeletedAt(userId, user.getDeletedAt());
+
+            // when
+            boolean exists = userMapper.existsById(userId);
+
+            // then
+            assertThat(exists).isFalse();
         }
     }
 }

--- a/src/test/java/buncheoleasy/user/infrastructure/shipping/ShippingAddressMapperTest.java
+++ b/src/test/java/buncheoleasy/user/infrastructure/shipping/ShippingAddressMapperTest.java
@@ -1,0 +1,287 @@
+package buncheoleasy.user.infrastructure.shipping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import buncheoleasy.user.domain.User;
+import buncheoleasy.user.domain.shipping.ShippingAddress;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
+import buncheoleasy.user.infrastructure.UserMapper;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+@MybatisTest
+@ActiveProfiles("test")
+@DisplayName("ShippingAddressMapper 테스트")
+class ShippingAddressMapperTest {
+
+    @Autowired
+    private ShippingAddressMapper shippingAddressMapper;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.create("KAKAO", "123456", "test@example.com");
+        userMapper.insert(user);
+        userId = user.getId();
+    }
+
+    @Nested
+    @DisplayName("배송지 저장 테스트")
+    class InsertTest {
+
+        @Test
+        void 배송지를_저장하면_ID가_할당된다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+
+            // when
+            shippingAddressMapper.insert(address);
+
+            // then
+            assertThat(address.getId()).isNotNull();
+            assertThat(address.getId()).isPositive();
+        }
+
+        @Test
+        void 동일한_유저의_다른_배송지를_여러_개_저장할_수_있다() {
+            // given
+            ShippingAddress address1 = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+            ShippingAddress address2 = ShippingAddress.create(userId, "CU_HALF", "CU 홍대입구점");
+
+            // when
+            shippingAddressMapper.insert(address1);
+            shippingAddressMapper.insert(address2);
+
+            // then
+            assertThat(address1.getId()).isNotEqualTo(address2.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Id로 배송지 조회 테스트")
+    class FindByIdTest {
+
+        @Test
+        void ID로_배송지를_조회할_수_있다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+            shippingAddressMapper.insert(address);
+
+            // when
+            Optional<ShippingAddress> found = shippingAddressMapper.findById(address.getId());
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(address.getId());
+            assertThat(found.get().getUserId()).isEqualTo(userId);
+            assertThat(found.get().getShippingMethod()).isEqualTo(ShippingMethod.GS25_HALF);
+            assertThat(found.get().getStoreName()).isEqualTo("GS25 강남역점");
+        }
+
+        @Test
+        void 존재하지_않는_ID로_조회하면_empty를_반환한다() {
+            // when
+            Optional<ShippingAddress> found = shippingAddressMapper.findById(999999L);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저의 배송지 목록 조회 테스트")
+    class FindAllByUserTest {
+
+        @Test
+        void userId로_배송지_목록을_조회할_수_있다() {
+            // given
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점"));
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "CU_HALF", "CU 홍대입구점"));
+
+            // when
+            List<ShippingAddress> addresses = shippingAddressMapper.findAllByUser(userId);
+
+            // then
+            assertThat(addresses).hasSize(2);
+            assertThat(addresses).extracting(ShippingAddress::getUserId).containsOnly(userId);
+        }
+
+        @Test
+        void 다른_유저의_배송지는_조회되지_않는다() {
+            // given
+            User otherUser = User.create("KAKAO", "other_user", "other@example.com");
+            userMapper.insert(otherUser);
+
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점"));
+            shippingAddressMapper.insert(ShippingAddress.create(otherUser.getId(), "CU_HALF", "CU 홍대입구점"));
+
+            // when
+            List<ShippingAddress> addresses = shippingAddressMapper.findAllByUser(userId);
+
+            // then
+            assertThat(addresses).hasSize(1);
+            assertThat(addresses.getFirst().getShippingMethod()).isEqualTo(ShippingMethod.GS25_HALF);
+        }
+
+        @Test
+        void 배송지가_없으면_빈_리스트를_반환한다() {
+            // when
+            List<ShippingAddress> addresses = shippingAddressMapper.findAllByUser(userId);
+
+            // then
+            assertThat(addresses).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 수정 테스트")
+    class UpdateTest {
+
+        @Test
+        void 배송지_정보를_업데이트할_수_있다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+            shippingAddressMapper.insert(address);
+            address.update("CU_HALF", "CU 홍대입구점");
+
+            // when
+            shippingAddressMapper.update(address);
+
+            // then
+            ShippingAddress updated = shippingAddressMapper.findById(address.getId()).orElseThrow();
+            assertThat(updated.getShippingMethod()).isEqualTo(ShippingMethod.CU_HALF);
+            assertThat(updated.getStoreName()).isEqualTo("CU 홍대입구점");
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 삭제 테스트")
+    class DeleteTest {
+
+        @Test
+        void 배송지를_삭제할_수_있다() {
+            // given
+            ShippingAddress address = ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점");
+            shippingAddressMapper.insert(address);
+            Long addressId = address.getId();
+
+            // when
+            shippingAddressMapper.delete(addressId);
+
+            // then
+            assertThat(shippingAddressMapper.findById(addressId)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 배송지 목록 개수 조회 테스트")
+    class CountByUserIdTest {
+
+        @Test
+        void userId로_배송지_개수를_조회할_수_있다() {
+            // given
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점"));
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "CU_HALF", "CU 홍대입구점"));
+
+            // when
+            int count = shippingAddressMapper.countByUserId(userId);
+
+            // then
+            assertThat(count).isEqualTo(2);
+        }
+
+        @Test
+        void 다른_유저의_배송지는_카운트되지_않는다() {
+            // given
+            User otherUser = User.create("KAKAO", "other_user", "other@example.com");
+            userMapper.insert(otherUser);
+            shippingAddressMapper.insert(ShippingAddress.create(otherUser.getId(), "GS25_HALF", "GS25 강남역점"));
+
+            // when: userId 기준으로 카운트
+            int count = shippingAddressMapper.countByUserId(userId);
+
+            // then
+            assertThat(count).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저의 동일한 배송지 존재 여부 확인 테스트")
+    class ExistsTest {
+
+        @Test
+        void 동일한_배송지가_존재하면_true를_반환한다() {
+            // given
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점"));
+
+            // when
+            boolean exists = shippingAddressMapper.existsByUserIdAndShippingMethodAndStoreName(
+                    userId, "GS25_HALF", "GS25 강남역점");
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void 동일한_배송지가_없으면_false를_반환한다() {
+            // when
+            boolean exists = shippingAddressMapper.existsByUserIdAndShippingMethodAndStoreName(
+                    userId, "GS25_HALF", "GS25 강남역점");
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void 배송방법이_다르면_false를_반환한다() {
+            // given
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점"));
+
+            // when
+            boolean exists = shippingAddressMapper.existsByUserIdAndShippingMethodAndStoreName(
+                    userId, "CU_HALF", "GS25 강남역점");
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void 지점명이_다르면_false를_반환한다() {
+            // given
+            shippingAddressMapper.insert(ShippingAddress.create(userId, "GS25_HALF", "GS25 강남역점"));
+
+            // when
+            boolean exists = shippingAddressMapper.existsByUserIdAndShippingMethodAndStoreName(
+                    userId, "GS25_HALF", "GS25 신촌역점");
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void 다른_유저의_동일한_배송지는_해당_유저의_중복으로_처리되지_않는다() {
+            // given
+            User otherUser = User.create("KAKAO", "other_user", "other@example.com");
+            userMapper.insert(otherUser);
+            shippingAddressMapper.insert(ShippingAddress.create(otherUser.getId(), "GS25_HALF", "GS25 강남역점"));
+
+            // when: userId 기준으로 조회
+            boolean exists = shippingAddressMapper.existsByUserIdAndShippingMethodAndStoreName(
+                    userId, "GS25_HALF", "GS25 강남역점");
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+}

--- a/src/test/java/buncheoleasy/user/presentation/ShippingAddressControllerTest.java
+++ b/src/test/java/buncheoleasy/user/presentation/ShippingAddressControllerTest.java
@@ -1,0 +1,131 @@
+package buncheoleasy.user.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
+import buncheoleasy.user.application.ShippingAddressService;
+import buncheoleasy.user.dto.response.ShippingAddressResponse;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("ShippingAddressController 테스트")
+class ShippingAddressControllerTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ShippingAddressService shippingAddressService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private RequestPostProcessor mockAuth() {
+        return (MockHttpServletRequest request) -> {
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(USER_ID, null, Collections.emptyList())
+            );
+            return request;
+        };
+    }
+
+    @Test
+    void 배송지_등록이_성공하면_201을_반환한다() throws Exception {
+        mockMvc.perform(post("/v1/users/me/shipping-addresses")
+                        .with(mockAuth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shippingMethod\":\"GS25_HALF\",\"storeName\":\"GS25 강남역점\"}"))
+                .andExpect(status().isCreated());
+
+        then(shippingAddressService).should().registerShippingAddress(USER_ID,
+                new buncheoleasy.user.dto.request.ShippingAddressRequest("GS25_HALF", "GS25 강남역점"));
+    }
+
+    @Test
+    void 배송지_등록_요청_검증에_실패하면_400과_표준_에러코드를_반환한다() throws Exception {
+        mockMvc.perform(post("/v1/users/me/shipping-addresses")
+                        .with(mockAuth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shippingMethod\":\"GS25_HALF\",\"storeName\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.INVALID_INPUT_VALUE.getCode())));
+    }
+
+    @Test
+    void 배송지_수정_중_BusinessException이_발생하면_해당_HTTP_상태코드로_매핑된다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.SHIPPING_ADDRESS_FORBIDDEN))
+                .given(shippingAddressService)
+                .modifyShippingAddress(USER_ID, 10L,
+                        new buncheoleasy.user.dto.request.ShippingAddressRequest("CU_HALF", "CU 홍대입구점"));
+
+        mockMvc.perform(put("/v1/users/me/shipping-addresses/10")
+                        .with(mockAuth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shippingMethod\":\"CU_HALF\",\"storeName\":\"CU 홍대입구점\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.SHIPPING_ADDRESS_FORBIDDEN.getCode())));
+    }
+
+    @Test
+    void 배송지_삭제_중_BusinessException이_발생하면_해당_HTTP_상태코드로_매핑된다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.SHIPPING_ADDRESS_NOT_FOUND))
+                .given(shippingAddressService)
+                .removeShippingAddress(USER_ID, 10L);
+
+        mockMvc.perform(delete("/v1/users/me/shipping-addresses/10")
+                        .with(mockAuth()))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.SHIPPING_ADDRESS_NOT_FOUND.getCode())));
+    }
+
+    @Test
+    void 내_배송지_목록_조회가_성공하면_200과_응답목록을_반환한다() throws Exception {
+        given(shippingAddressService.getUserShippingAddresses(USER_ID))
+                .willReturn(List.of(
+                        ShippingAddressResponse.of(1L, "GS25_HALF", "GS25 강남역점"),
+                        ShippingAddressResponse.of(2L, "CU_HALF", "CU 홍대입구점")
+                ));
+
+        mockMvc.perform(get("/v1/users/me/shipping-addresses").with(mockAuth()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].shippingMethod").value("GS25_HALF"))
+                .andExpect(jsonPath("$[1].id").value(2L))
+                .andExpect(jsonPath("$[1].shippingMethod").value("CU_HALF"));
+    }
+}

--- a/src/test/java/buncheoleasy/user/presentation/UserControllerTest.java
+++ b/src/test/java/buncheoleasy/user/presentation/UserControllerTest.java
@@ -1,17 +1,20 @@
-package buncheoleasy.auth.presentation;
+package buncheoleasy.user.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import buncheoleasy.auth.TokenPair;
-import buncheoleasy.auth.application.SocialLoginService;
-import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
 import buncheoleasy.global.exception.domain.BusinessException;
 import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
+import buncheoleasy.user.application.UserService;
+import buncheoleasy.user.dto.response.UserProfileResponse;
 import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,8 +34,8 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
-@DisplayName("AuthController WebMvc 테스트")
-class AuthControllerWebMvcTest {
+@DisplayName("UserController 테스트")
+class UserControllerTest {
 
     private static final Long USER_ID = 1L;
 
@@ -40,7 +43,7 @@ class AuthControllerWebMvcTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private SocialLoginService socialLoginService;
+    private UserService userService;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
@@ -60,44 +63,44 @@ class AuthControllerWebMvcTest {
     }
 
     @Test
-    void 토큰_재발급_요청이_성공하면_200을_반환한다() throws Exception {
-        given(socialLoginService.reissueTokens("valid-refresh"))
-                .willReturn(new TokenPair("new-access", "new-refresh"));
+    void 내_프로필_조회가_성공하면_200과_응답본문을_반환한다() throws Exception {
+        given(userService.getUserProfile(USER_ID))
+                .willReturn(UserProfileResponse.of("KAKAO", "test@example.com", "테스트닉", "01012345678"));
 
-        mockMvc.perform(post("/v1/auth/reissue-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"refreshToken\":\"valid-refresh\"}"))
+        mockMvc.perform(get("/v1/users/me").with(mockAuth()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").value("new-access"))
-                .andExpect(jsonPath("$.refreshToken").value("new-refresh"));
+                .andExpect(jsonPath("$.provider").value("KAKAO"))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.nickname").value("테스트닉"))
+                .andExpect(jsonPath("$.phoneNumber").value("01012345678"));
     }
 
     @Test
-    void 토큰_재발급_요청_검증에_실패하면_400과_표준_에러코드를_반환한다() throws Exception {
-        mockMvc.perform(post("/v1/auth/reissue-token")
+    void 프로필_수정_요청_검증에_실패하면_400과_표준_에러코드를_반환한다() throws Exception {
+        mockMvc.perform(put("/v1/users/me")
+                        .with(mockAuth())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"refreshToken\":\"\"}"))
+                        .content("{\"nickname\":\"테스트@유저\",\"phoneNumber\":\"01012345678\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.INVALID_INPUT_VALUE.getCode())));
     }
 
     @Test
-    void 토큰_재발급_중_BusinessException이_발생하면_해당_HTTP_상태코드로_매핑된다() throws Exception {
-        given(socialLoginService.reissueTokens("invalid-refresh"))
-                .willThrow(new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+    void 회원탈퇴_중_BusinessException이_발생하면_해당_HTTP_상태코드로_매핑된다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .given(userService)
+                .withdraw(USER_ID);
 
-        mockMvc.perform(post("/v1/auth/reissue-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"refreshToken\":\"invalid-refresh\"}"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.AUTH_INVALID_TOKEN.getCode())));
+        mockMvc.perform(delete("/v1/users/me").with(mockAuth()))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(ErrorCode.USER_NOT_FOUND.getCode())));
     }
 
     @Test
-    void 로그아웃_요청이_성공하면_204를_반환한다() throws Exception {
-        mockMvc.perform(post("/v1/auth/logout").with(mockAuth()))
+    void 회원탈퇴가_성공하면_204를_반환한다() throws Exception {
+        mockMvc.perform(delete("/v1/users/me").with(mockAuth()))
                 .andExpect(status().isNoContent());
 
-        then(socialLoginService).should().logout(USER_ID);
+        then(userService).should().withdraw(USER_ID);
     }
 }

--- a/src/test/resources/schema-test.sql
+++ b/src/test/resources/schema-test.sql
@@ -1,4 +1,5 @@
--- Test H2 Database용 users 테이블 생성
+-- Test H2 Database용 테이블 생성
+DROP TABLE IF EXISTS shipping_addresses;
 DROP TABLE IF EXISTS users;
 
 CREATE TABLE users
@@ -23,11 +24,24 @@ CREATE TABLE users
     PRIMARY KEY (id)
 );
 
--- 가상 컬럼에 유니크 인덱스
+-- soft delete 패턴의 유니크 제약 (탈퇴 후 재가입 허용 여부를 DB 레벨에서 보장)
 CREATE UNIQUE INDEX uq_users_active_social_account ON users (active_provider, active_provider_id);
 CREATE UNIQUE INDEX uq_users_active_nickname ON users (active_nickname);
 CREATE UNIQUE INDEX uq_users_active_phone ON users (active_phone);
 
--- 일반 인덱스
-CREATE INDEX idx_users_provider_id ON users (provider_id);
-CREATE INDEX idx_users_nickname ON users (nickname);
+-- Test H2 Database용 shipping_addresses 테이블 생성
+CREATE TABLE shipping_addresses
+(
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id         BIGINT       NOT NULL,
+    shipping_method VARCHAR(20)  NOT NULL,
+    store_name      VARCHAR(100) NOT NULL,
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_shipping_addresses_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+-- 중복 배송지 제약 (동일 유저의 동일 배송방법+지점명 등록 불가)
+CREATE UNIQUE INDEX uq_shipping_addresses_user_method_store ON shipping_addresses (user_id, shipping_method, store_name);


### PR DESCRIPTION
## 관련 이슈
- close #17
- close #1

## 구현 내용
  **테스트 환경 설정**
  - `spring-boot-starter-webmvc-test`, `spring-security-test` 의존성 추가
  - 테스트 DB 스크립트에 shipping_addresses 테이블 스키마 추가

  **User / ShippingAddress 테스트**
  - 도메인 엔티티, 도메인 서비스, 인프라(Mapper), 애플리케이션 서비스, 컨트롤러 각 레이어 테스트 추가

  **Auth 모듈 테스트**
  - JWT 토큰 프로바이더, 인증 필터, OAuth2 핸들러, Redis 토큰 저장소, 컨트롤러 각 컴포넌트 테스트 추가

  **기타 수정**
  - OAuth2 로그인 시 소셜 이메일 누락 검증 추가
  - /error 경로 시큐리티 필터 인증 없이 접근 가능하도록 설정