### PR TITLE
[FEAT] 분철 상태 진행 및 배송 관리 API 구현

### DIFF
--- a/src/main/java/buncheoleasy/buncheol/application/BuncheolService.java
+++ b/src/main/java/buncheoleasy/buncheol/application/BuncheolService.java
@@ -4,6 +4,7 @@ import buncheoleasy.buncheol.domain.Buncheol;
 import buncheoleasy.buncheol.domain.BuncheolDomainService;
 import buncheoleasy.buncheol.domain.BuncheolModificationPolicy;
 import buncheoleasy.buncheol.domain.BuncheolParams;
+import buncheoleasy.buncheol.domain.BuncheolStatus;
 import buncheoleasy.buncheol.domain.image.BuncheolImageDomainService;
 import buncheoleasy.buncheol.domain.member.BuncheolMember;
 import buncheoleasy.buncheol.domain.member.BuncheolMemberDomainService;
@@ -26,7 +27,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -95,6 +95,13 @@ public class BuncheolService {
     if (!images.isEmpty()) {
       eventPublisher.publishEvent(new BuncheolImageUploadEvent(buncheolId, images));
     }
+  }
+
+  public void advanceBuncheolStatus(
+      final Long hostId, final Long buncheolId, final BuncheolStatus nextStatus) {
+    Buncheol buncheol = buncheolDomainService.getBuncheol(buncheolId);
+    buncheol.validateOwner(hostId);
+    buncheolDomainService.advanceBuncheolStatus(buncheol, nextStatus);
   }
 
   public void cancelBuncheol(final Long hostId, final Long buncheolId) {

--- a/src/main/java/buncheoleasy/buncheol/application/BuncheolService.java
+++ b/src/main/java/buncheoleasy/buncheol/application/BuncheolService.java
@@ -101,14 +101,16 @@ public class BuncheolService {
       final Long hostId, final Long buncheolId, final BuncheolStatus nextStatus) {
     Buncheol buncheol = buncheolDomainService.getBuncheol(buncheolId);
     buncheol.validateOwner(hostId);
-    buncheolDomainService.advanceBuncheolStatus(buncheol, nextStatus);
+    final BuncheolStatus previousStatus = buncheol.getStatus();
+    buncheolDomainService.advanceBuncheolStatus(buncheol, nextStatus, previousStatus);
   }
 
   public void cancelBuncheol(final Long hostId, final Long buncheolId) {
     Buncheol buncheol = buncheolDomainService.getBuncheol(buncheolId);
     buncheol.validateOwner(hostId);
     // TODO: 추후 참여자 존재 시 패널티 부과 및 환불 처리 분기 추가
-    buncheolDomainService.cancelBuncheol(buncheol);
+    final BuncheolStatus previousStatus = buncheol.getStatus();
+    buncheolDomainService.cancelBuncheol(buncheol, previousStatus);
   }
 
   /** 참여자 없는 경우 분철 수정: 전체 업데이트 + 멤버 삭제 후 재생성 */

--- a/src/main/java/buncheoleasy/buncheol/application/ParticipationPaymentHandler.java
+++ b/src/main/java/buncheoleasy/buncheol/application/ParticipationPaymentHandler.java
@@ -3,10 +3,16 @@ package buncheoleasy.buncheol.application;
 import buncheoleasy.buncheol.domain.participation.Participation;
 import buncheoleasy.buncheol.domain.participation.ParticipationDomainService;
 import buncheoleasy.buncheol.domain.participation.ParticipationStatus;
+import buncheoleasy.delivery.domain.Delivery;
+import buncheoleasy.delivery.domain.DeliveryDomainService;
 import buncheoleasy.global.exception.domain.BusinessException;
 import buncheoleasy.global.exception.domain.ErrorCode;
 import buncheoleasy.payment.application.PaymentCompletionHandler;
 import buncheoleasy.payment.domain.PaymentPhase;
+import buncheoleasy.user.domain.User;
+import buncheoleasy.user.domain.UserDomainService;
+import buncheoleasy.user.domain.shipping.ShippingAddress;
+import buncheoleasy.user.domain.shipping.ShippingAddressDomainService;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +27,9 @@ public class ParticipationPaymentHandler implements PaymentCompletionHandler {
   private static final String FAIL_REASON_INSTANT_CONFIRMED = "즉시 구매 확정으로 인한 자동 실패 처리";
 
   private final ParticipationDomainService participationDomainService;
+  private final DeliveryDomainService deliveryDomainService;
+  private final ShippingAddressDomainService shippingAddressDomainService;
+  private final UserDomainService userDomainService;
   private final Clock clock;
 
   @Override
@@ -50,6 +59,26 @@ public class ParticipationPaymentHandler implements PaymentCompletionHandler {
       participationDomainService.failAllOpenBids(
           participation.getBuncheolMemberId(), FAIL_REASON_INSTANT_CONFIRMED);
     }
+
+    // INSTANT 확정 참여의 배송 스냅샷은 분철 마감 시점에 일괄 생성 (TODO: 마감 로직 구현 시 처리)
+    if (paymentPhase == PaymentPhase.BALANCE) {
+      createDeliverySnapshot(participation);
+    }
+  }
+
+  private void createDeliverySnapshot(final Participation participation) {
+    ShippingAddress shippingAddress =
+        shippingAddressDomainService.getShippingAddress(participation.getShippingAddressId());
+    User user = userDomainService.getUser(participation.getParticipantId());
+
+    Delivery delivery =
+        Delivery.createSnapshot(
+            participation.getId(),
+            shippingAddress.getShippingMethod(),
+            shippingAddress.getStoreName(),
+            user.getNickname().value(),
+            user.getPhoneNumber().value());
+    deliveryDomainService.createDelivery(delivery);
   }
 
   @Override

--- a/src/main/java/buncheoleasy/buncheol/domain/Buncheol.java
+++ b/src/main/java/buncheoleasy/buncheol/domain/Buncheol.java
@@ -134,6 +134,13 @@ public class Buncheol {
     status = BuncheolStatus.CANCELLED;
   }
 
+  public void advanceStatus(final BuncheolStatus nextStatus) {
+    if (!status.canAdvanceTo(nextStatus)) {
+      throw new BusinessException(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED);
+    }
+    this.status = nextStatus;
+  }
+
   private void validate(final Long hostId, final BuncheolParams params) {
     validateHostAndParams(hostId, params);
     validateGroupName(params.groupName());

--- a/src/main/java/buncheoleasy/buncheol/domain/BuncheolDomainService.java
+++ b/src/main/java/buncheoleasy/buncheol/domain/BuncheolDomainService.java
@@ -29,4 +29,9 @@ public class BuncheolDomainService {
     buncheol.cancel();
     buncheolRepository.updateStatus(buncheol.getId(), buncheol.getStatus());
   }
+
+  public void advanceBuncheolStatus(final Buncheol buncheol, final BuncheolStatus nextStatus) {
+    buncheol.advanceStatus(nextStatus);
+    buncheolRepository.updateStatus(buncheol.getId(), buncheol.getStatus());
+  }
 }

--- a/src/main/java/buncheoleasy/buncheol/domain/BuncheolDomainService.java
+++ b/src/main/java/buncheoleasy/buncheol/domain/BuncheolDomainService.java
@@ -25,13 +25,23 @@ public class BuncheolDomainService {
     buncheolRepository.update(buncheol.getId(), params);
   }
 
-  public void cancelBuncheol(final Buncheol buncheol) {
+  public void cancelBuncheol(final Buncheol buncheol, final BuncheolStatus expectedStatus) {
     buncheol.cancel();
-    buncheolRepository.updateStatus(buncheol.getId(), buncheol.getStatus());
+    updateBuncheolStatus(buncheol, expectedStatus);
   }
 
-  public void advanceBuncheolStatus(final Buncheol buncheol, final BuncheolStatus nextStatus) {
+  public void advanceBuncheolStatus(
+      final Buncheol buncheol,
+      final BuncheolStatus nextStatus,
+      final BuncheolStatus expectedStatus) {
     buncheol.advanceStatus(nextStatus);
-    buncheolRepository.updateStatus(buncheol.getId(), buncheol.getStatus());
+    updateBuncheolStatus(buncheol, expectedStatus);
+  }
+
+  private void updateBuncheolStatus(final Buncheol buncheol, final BuncheolStatus expectedStatus) {
+    boolean updated = buncheolRepository.updateStatus(buncheol, expectedStatus);
+    if (!updated) {
+      throw new BusinessException(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED);
+    }
   }
 }

--- a/src/main/java/buncheoleasy/buncheol/domain/BuncheolRepository.java
+++ b/src/main/java/buncheoleasy/buncheol/domain/BuncheolRepository.java
@@ -10,5 +10,5 @@ public interface BuncheolRepository {
 
   void update(Long id, BuncheolParams params);
 
-  void updateStatus(Long id, BuncheolStatus status);
+  boolean updateStatus(Buncheol buncheol, BuncheolStatus expectedStatus);
 }

--- a/src/main/java/buncheoleasy/buncheol/domain/BuncheolStatus.java
+++ b/src/main/java/buncheoleasy/buncheol/domain/BuncheolStatus.java
@@ -23,4 +23,13 @@ public enum BuncheolStatus {
       default -> false;
     };
   }
+
+  // 개최자가 수동으로 진행 가능한 전이 (마감 제외)
+  public boolean canAdvanceTo(BuncheolStatus next) {
+    return switch (this) {
+      case CLOSED -> next == GOODS_ORDERED;
+      case GOODS_ORDERED -> next == SELLER_SHIPPING;
+      default -> false;
+    };
+  }
 }

--- a/src/main/java/buncheoleasy/buncheol/dto/request/BuncheolStatusRequest.java
+++ b/src/main/java/buncheoleasy/buncheol/dto/request/BuncheolStatusRequest.java
@@ -1,0 +1,6 @@
+package buncheoleasy.buncheol.dto.request;
+
+import buncheoleasy.buncheol.domain.BuncheolStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record BuncheolStatusRequest(@NotNull BuncheolStatus status) {}

--- a/src/main/java/buncheoleasy/buncheol/infrastructure/BuncheolMapper.java
+++ b/src/main/java/buncheoleasy/buncheol/infrastructure/BuncheolMapper.java
@@ -16,5 +16,6 @@ public interface BuncheolMapper {
 
   void update(@Param("id") Long id, @Param("params") BuncheolParams params);
 
-  void updateStatus(@Param("id") Long id, @Param("status") BuncheolStatus status);
+  int updateStatus(
+      @Param("buncheol") Buncheol buncheol, @Param("expectedStatus") BuncheolStatus expectedStatus);
 }

--- a/src/main/java/buncheoleasy/buncheol/infrastructure/BuncheolMapper.xml
+++ b/src/main/java/buncheoleasy/buncheol/infrastructure/BuncheolMapper.xml
@@ -119,9 +119,10 @@
   <!-- 분철 상태 업데이트 -->
   <update id="updateStatus">
     UPDATE buncheols
-    SET status     = #{status},
+    SET status     = #{buncheol.status},
         updated_at = NOW()
-    WHERE id = #{id}
+    WHERE id = #{buncheol.id}
+      AND status = #{expectedStatus}
   </update>
 
 </mapper>

--- a/src/main/java/buncheoleasy/buncheol/infrastructure/MybatisBuncheolRepository.java
+++ b/src/main/java/buncheoleasy/buncheol/infrastructure/MybatisBuncheolRepository.java
@@ -31,7 +31,7 @@ public class MybatisBuncheolRepository implements BuncheolRepository {
   }
 
   @Override
-  public void updateStatus(Long id, BuncheolStatus status) {
-    buncheolMapper.updateStatus(id, status);
+  public boolean updateStatus(Buncheol buncheol, BuncheolStatus expectedStatus) {
+    return buncheolMapper.updateStatus(buncheol, expectedStatus) > 0;
   }
 }

--- a/src/main/java/buncheoleasy/buncheol/presentation/BuncheolController.java
+++ b/src/main/java/buncheoleasy/buncheol/presentation/BuncheolController.java
@@ -3,6 +3,7 @@ package buncheoleasy.buncheol.presentation;
 import buncheoleasy.buncheol.application.BuncheolService;
 import buncheoleasy.buncheol.application.ImageFile;
 import buncheoleasy.buncheol.dto.request.BuncheolModifyRequest;
+import buncheoleasy.buncheol.dto.request.BuncheolStatusRequest;
 import buncheoleasy.buncheol.dto.request.HoldBuncheolRequest;
 import buncheoleasy.global.exception.domain.BusinessException;
 import buncheoleasy.global.exception.domain.ErrorCode;
@@ -15,9 +16,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,6 +49,15 @@ public class BuncheolController {
       @Valid @RequestPart("request") final BuncheolModifyRequest request,
       @RequestPart(value = "images", required = false) final List<MultipartFile> images) {
     buncheolService.modifyBuncheol(hostId, id, request, toImageFiles(images));
+    return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping("/{id}/status")
+  public ResponseEntity<Void> advanceBuncheolStatus(
+      @AuthenticationPrincipal final Long hostId,
+      @PathVariable final Long id,
+      @Valid @RequestBody final BuncheolStatusRequest request) {
+    buncheolService.advanceBuncheolStatus(hostId, id, request.status());
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/buncheoleasy/delivery/application/DeliveryService.java
+++ b/src/main/java/buncheoleasy/delivery/application/DeliveryService.java
@@ -1,0 +1,55 @@
+package buncheoleasy.delivery.application;
+
+import buncheoleasy.buncheol.domain.Buncheol;
+import buncheoleasy.buncheol.domain.BuncheolDomainService;
+import buncheoleasy.buncheol.domain.participation.Participation;
+import buncheoleasy.buncheol.domain.participation.ParticipationDomainService;
+import buncheoleasy.delivery.domain.Delivery;
+import buncheoleasy.delivery.domain.DeliveryDomainService;
+import buncheoleasy.delivery.domain.DeliveryStatus;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+  private final DeliveryDomainService deliveryDomainService;
+  private final ParticipationDomainService participationDomainService;
+  private final BuncheolDomainService buncheolDomainService;
+  private final Clock clock;
+
+  public void registerTracking(
+      final Long hostId, final Long deliveryId, final String trackingNumber) {
+    Delivery delivery = deliveryDomainService.getDelivery(deliveryId);
+
+    // 참여 → 분철 → 개최자 검증
+    Participation participation =
+        participationDomainService.getParticipation(delivery.getParticipationId());
+    Buncheol buncheol = buncheolDomainService.getBuncheol(participation.getBuncheolId());
+    buncheol.validateOwner(hostId);
+
+    DeliveryStatus previousStatus = delivery.getStatus();
+    delivery.registerTracking(trackingNumber, LocalDateTime.now(clock));
+    deliveryDomainService.updateDeliveryStatus(delivery, previousStatus);
+  }
+
+  public void confirmReceipt(final Long participantId, final Long deliveryId) {
+    Delivery delivery = deliveryDomainService.getDelivery(deliveryId);
+
+    // 참여자 본인 검증
+    Participation participation =
+        participationDomainService.getParticipation(delivery.getParticipationId());
+    if (!participation.getParticipantId().equals(participantId)) {
+      throw new BusinessException(ErrorCode.DELIVERY_NO_PERMISSION);
+    }
+
+    DeliveryStatus previousStatus = delivery.getStatus();
+    delivery.confirmReceipt(LocalDateTime.now(clock));
+    deliveryDomainService.updateDeliveryStatus(delivery, previousStatus);
+  }
+}

--- a/src/main/java/buncheoleasy/delivery/domain/Delivery.java
+++ b/src/main/java/buncheoleasy/delivery/domain/Delivery.java
@@ -1,0 +1,130 @@
+package buncheoleasy.delivery.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class Delivery {
+
+  private Long id;
+  private final Long participationId;
+  private final ShippingMethod shippingMethod;
+  private final String storeName;
+  private final String receiverNickname;
+  private final String receiverPhoneNumber;
+  private String trackingNumber;
+  private LocalDateTime trackingRegisteredAt;
+  private LocalDateTime deliveredAt;
+  private LocalDateTime receivedAt;
+  private DeliveryStatus status;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static Delivery createSnapshot(
+      final Long participationId,
+      final ShippingMethod shippingMethod,
+      final String storeName,
+      final String receiverNickname,
+      final String receiverPhoneNumber) {
+    return new Delivery(
+        participationId, shippingMethod, storeName, receiverNickname, receiverPhoneNumber);
+  }
+
+  private Delivery(
+      final Long participationId,
+      final ShippingMethod shippingMethod,
+      final String storeName,
+      final String receiverNickname,
+      final String receiverPhoneNumber) {
+    validateSnapshot(
+        participationId, shippingMethod, storeName, receiverNickname, receiverPhoneNumber);
+    this.participationId = participationId;
+    this.shippingMethod = shippingMethod;
+    this.storeName = storeName;
+    this.receiverNickname = receiverNickname;
+    this.receiverPhoneNumber = receiverPhoneNumber;
+    this.status = DeliveryStatus.SNAPSHOTTED;
+  }
+
+  // MyBatis 조회 전용 생성자
+  private Delivery(
+      final Long id,
+      final Long participationId,
+      final String shippingMethod,
+      final String storeName,
+      final String receiverNickname,
+      final String receiverPhoneNumber,
+      final String trackingNumber,
+      final LocalDateTime trackingRegisteredAt,
+      final LocalDateTime deliveredAt,
+      final LocalDateTime receivedAt,
+      final DeliveryStatus status,
+      final LocalDateTime createdAt,
+      final LocalDateTime updatedAt) {
+    this.id = id;
+    this.participationId = participationId;
+    this.shippingMethod = ShippingMethod.of(shippingMethod);
+    this.storeName = storeName;
+    this.receiverNickname = receiverNickname;
+    this.receiverPhoneNumber = receiverPhoneNumber;
+    this.trackingNumber = trackingNumber;
+    this.trackingRegisteredAt = trackingRegisteredAt;
+    this.deliveredAt = deliveredAt;
+    this.receivedAt = receivedAt;
+    this.status = status;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public void registerTracking(final String trackingNumber, final LocalDateTime now) {
+    if (trackingNumber == null || trackingNumber.isBlank()) {
+      throw new BusinessException(ErrorCode.DELIVERY_TRACKING_NUMBER_REQUIRED);
+    }
+    if (status == DeliveryStatus.SHIPPING) {
+      // 이미 SHIPPING이면 운송장 번호만 업데이트
+      this.trackingNumber = trackingNumber;
+      this.trackingRegisteredAt = now;
+      return;
+    }
+    if (status != DeliveryStatus.SNAPSHOTTED) {
+      throw new BusinessException(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+    this.trackingNumber = trackingNumber;
+    this.trackingRegisteredAt = now;
+    this.status = DeliveryStatus.SHIPPING;
+  }
+
+  public void confirmReceipt(final LocalDateTime now) {
+    if (status != DeliveryStatus.SHIPPING && status != DeliveryStatus.DELIVERED) {
+      throw new BusinessException(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+    this.receivedAt = now;
+    this.status = DeliveryStatus.RECEIVED;
+  }
+
+  private void validateSnapshot(
+      final Long participationId,
+      final ShippingMethod shippingMethod,
+      final String storeName,
+      final String receiverNickname,
+      final String receiverPhoneNumber) {
+    if (participationId == null) {
+      throw new BusinessException(ErrorCode.PARTICIPATION_NOT_FOUND);
+    }
+    if (shippingMethod == null) {
+      throw new BusinessException(ErrorCode.DELIVERY_SHIPPING_METHOD_REQUIRED);
+    }
+    if (storeName == null || storeName.isBlank()) {
+      throw new BusinessException(ErrorCode.DELIVERY_STORE_NAME_REQUIRED);
+    }
+    if (receiverNickname == null || receiverNickname.isBlank()) {
+      throw new BusinessException(ErrorCode.DELIVERY_RECEIVER_NICKNAME_REQUIRED);
+    }
+    if (receiverPhoneNumber == null || receiverPhoneNumber.isBlank()) {
+      throw new BusinessException(ErrorCode.DELIVERY_RECEIVER_PHONE_REQUIRED);
+    }
+  }
+}

--- a/src/main/java/buncheoleasy/delivery/domain/DeliveryDomainService.java
+++ b/src/main/java/buncheoleasy/delivery/domain/DeliveryDomainService.java
@@ -1,0 +1,36 @@
+package buncheoleasy.delivery.domain;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryDomainService {
+
+  private final DeliveryRepository deliveryRepository;
+
+  public Delivery createDelivery(final Delivery delivery) {
+    return deliveryRepository.save(delivery);
+  }
+
+  public Delivery getDelivery(final Long id) {
+    return deliveryRepository
+        .findById(id)
+        .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+  }
+
+  public Delivery getDeliveryByParticipationId(final Long participationId) {
+    return deliveryRepository
+        .findByParticipationId(participationId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+  }
+
+  public void updateDeliveryStatus(final Delivery delivery, final DeliveryStatus expectedStatus) {
+    boolean updated = deliveryRepository.updateStatus(delivery, expectedStatus);
+    if (!updated) {
+      throw new BusinessException(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+  }
+}

--- a/src/main/java/buncheoleasy/delivery/domain/DeliveryRepository.java
+++ b/src/main/java/buncheoleasy/delivery/domain/DeliveryRepository.java
@@ -1,0 +1,14 @@
+package buncheoleasy.delivery.domain;
+
+import java.util.Optional;
+
+public interface DeliveryRepository {
+
+  Delivery save(Delivery delivery);
+
+  Optional<Delivery> findById(Long id);
+
+  Optional<Delivery> findByParticipationId(Long participationId);
+
+  boolean updateStatus(Delivery delivery, DeliveryStatus expectedStatus);
+}

--- a/src/main/java/buncheoleasy/delivery/domain/DeliveryStatus.java
+++ b/src/main/java/buncheoleasy/delivery/domain/DeliveryStatus.java
@@ -1,0 +1,8 @@
+package buncheoleasy.delivery.domain;
+
+public enum DeliveryStatus {
+  SNAPSHOTTED,
+  SHIPPING,
+  DELIVERED,
+  RECEIVED;
+}

--- a/src/main/java/buncheoleasy/delivery/dto/request/TrackingRegistrationRequest.java
+++ b/src/main/java/buncheoleasy/delivery/dto/request/TrackingRegistrationRequest.java
@@ -1,0 +1,5 @@
+package buncheoleasy.delivery.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TrackingRegistrationRequest(@NotBlank String trackingNumber) {}

--- a/src/main/java/buncheoleasy/delivery/infrastructure/DeliveryMapper.java
+++ b/src/main/java/buncheoleasy/delivery/infrastructure/DeliveryMapper.java
@@ -1,0 +1,20 @@
+package buncheoleasy.delivery.infrastructure;
+
+import buncheoleasy.delivery.domain.Delivery;
+import buncheoleasy.delivery.domain.DeliveryStatus;
+import java.util.Optional;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface DeliveryMapper {
+
+  void insert(Delivery delivery);
+
+  Optional<Delivery> findById(Long id);
+
+  Optional<Delivery> findByParticipationId(Long participationId);
+
+  int updateStatus(
+      @Param("delivery") Delivery delivery, @Param("expectedStatus") DeliveryStatus expectedStatus);
+}

--- a/src/main/java/buncheoleasy/delivery/infrastructure/DeliveryMapper.xml
+++ b/src/main/java/buncheoleasy/delivery/infrastructure/DeliveryMapper.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="buncheoleasy.delivery.infrastructure.DeliveryMapper">
+
+  <resultMap id="deliveryResultMap" type="Delivery">
+    <constructor>
+      <idArg column="id" javaType="Long"/>
+      <arg column="participation_id" javaType="Long"/>
+      <arg column="shipping_method" javaType="String"/>
+      <arg column="store_name" javaType="String"/>
+      <arg column="receiver_nickname" javaType="String"/>
+      <arg column="receiver_phone_number" javaType="String"/>
+      <arg column="tracking_number" javaType="String"/>
+      <arg column="tracking_registered_at" javaType="java.time.LocalDateTime"/>
+      <arg column="delivered_at" javaType="java.time.LocalDateTime"/>
+      <arg column="received_at" javaType="java.time.LocalDateTime"/>
+      <arg column="status" javaType="DeliveryStatus"/>
+      <arg column="created_at" javaType="java.time.LocalDateTime"/>
+      <arg column="updated_at" javaType="java.time.LocalDateTime"/>
+    </constructor>
+  </resultMap>
+
+  <insert id="insert" parameterType="Delivery"
+    useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO deliveries (participation_id,
+                            shipping_method,
+                            store_name,
+                            receiver_nickname,
+                            receiver_phone_number,
+                            status,
+                            created_at,
+                            updated_at)
+    VALUES (#{participationId},
+            #{shippingMethod},
+            #{storeName},
+            #{receiverNickname},
+            #{receiverPhoneNumber},
+            #{status},
+            NOW(),
+            NOW())
+  </insert>
+
+  <select id="findById" resultMap="deliveryResultMap">
+    SELECT id,
+           participation_id,
+           shipping_method,
+           store_name,
+           receiver_nickname,
+           receiver_phone_number,
+           tracking_number,
+           tracking_registered_at,
+           delivered_at,
+           received_at,
+           status,
+           created_at,
+           updated_at
+    FROM deliveries
+    WHERE id = #{id}
+  </select>
+
+  <select id="findByParticipationId" resultMap="deliveryResultMap">
+    SELECT id,
+           participation_id,
+           shipping_method,
+           store_name,
+           receiver_nickname,
+           receiver_phone_number,
+           tracking_number,
+           tracking_registered_at,
+           delivered_at,
+           received_at,
+           status,
+           created_at,
+           updated_at
+    FROM deliveries
+    WHERE participation_id = #{participationId}
+  </select>
+
+  <update id="updateStatus">
+    UPDATE deliveries
+    SET tracking_number        = #{delivery.trackingNumber},
+        tracking_registered_at = #{delivery.trackingRegisteredAt},
+        delivered_at           = #{delivery.deliveredAt},
+        received_at            = #{delivery.receivedAt},
+        status                 = #{delivery.status},
+        updated_at             = NOW()
+    WHERE id = #{delivery.id}
+      AND status = #{expectedStatus}
+  </update>
+
+</mapper>

--- a/src/main/java/buncheoleasy/delivery/infrastructure/MybatisDeliveryRepository.java
+++ b/src/main/java/buncheoleasy/delivery/infrastructure/MybatisDeliveryRepository.java
@@ -1,0 +1,36 @@
+package buncheoleasy.delivery.infrastructure;
+
+import buncheoleasy.delivery.domain.Delivery;
+import buncheoleasy.delivery.domain.DeliveryRepository;
+import buncheoleasy.delivery.domain.DeliveryStatus;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MybatisDeliveryRepository implements DeliveryRepository {
+
+  private final DeliveryMapper deliveryMapper;
+
+  @Override
+  public Delivery save(final Delivery delivery) {
+    deliveryMapper.insert(delivery);
+    return delivery;
+  }
+
+  @Override
+  public Optional<Delivery> findById(final Long id) {
+    return deliveryMapper.findById(id);
+  }
+
+  @Override
+  public Optional<Delivery> findByParticipationId(final Long participationId) {
+    return deliveryMapper.findByParticipationId(participationId);
+  }
+
+  @Override
+  public boolean updateStatus(final Delivery delivery, final DeliveryStatus expectedStatus) {
+    return deliveryMapper.updateStatus(delivery, expectedStatus) > 0;
+  }
+}

--- a/src/main/java/buncheoleasy/delivery/presentation/DeliveryController.java
+++ b/src/main/java/buncheoleasy/delivery/presentation/DeliveryController.java
@@ -1,0 +1,38 @@
+package buncheoleasy.delivery.presentation;
+
+import buncheoleasy.delivery.application.DeliveryService;
+import buncheoleasy.delivery.dto.request.TrackingRegistrationRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/deliveries")
+@RequiredArgsConstructor
+public class DeliveryController {
+
+  private final DeliveryService deliveryService;
+
+  @PatchMapping("/{id}/tracking")
+  public ResponseEntity<Void> registerTracking(
+      @AuthenticationPrincipal final Long hostId,
+      @PathVariable final Long id,
+      @Valid @RequestBody final TrackingRegistrationRequest request) {
+    deliveryService.registerTracking(hostId, id, request.trackingNumber());
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/{id}/receipt")
+  public ResponseEntity<Void> confirmReceipt(
+      @AuthenticationPrincipal final Long participantId, @PathVariable final Long id) {
+    deliveryService.confirmReceipt(participantId, id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/buncheoleasy/global/exception/domain/ErrorCode.java
+++ b/src/main/java/buncheoleasy/global/exception/domain/ErrorCode.java
@@ -89,6 +89,7 @@ public enum ErrorCode {
   BUNCHEOL_NOT_FOUND("BCH-043", "존재하지 않는 분철입니다.", HttpStatus.NOT_FOUND),
   BUNCHEOL_NO_PERMISSION("BCH-044", "분철에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
   BUNCHEOL_CANCEL_NOT_ALLOWED("BCH-050", "현재 상태에서는 분철을 취소할 수 없습니다.", HttpStatus.CONFLICT),
+  BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED("BCH-051", "현재 상태에서 해당 상태로 변경할 수 없습니다.", HttpStatus.CONFLICT),
 
   BUNCHEOL_NOT_RECRUITING("BCH-060", "모집 중인 분철이 아닙니다.", HttpStatus.CONFLICT),
   PARTICIPATION_MEMBER_NOT_FOUND("BCH-061", "해당 분철에 존재하지 않는 멤버입니다.", HttpStatus.NOT_FOUND),
@@ -138,6 +139,11 @@ public enum ErrorCode {
   DELIVERY_STORE_NAME_REQUIRED("DLV-002", "편의점 지점명은 필수입니다.", HttpStatus.BAD_REQUEST),
   DELIVERY_RECEIVER_NICKNAME_REQUIRED("DLV-003", "수령인 닉네임은 필수입니다.", HttpStatus.BAD_REQUEST),
   DELIVERY_RECEIVER_PHONE_REQUIRED("DLV-004", "수령인 연락처는 필수입니다.", HttpStatus.BAD_REQUEST),
+  DELIVERY_TRACKING_NUMBER_REQUIRED("DLV-005", "운송장 번호는 필수입니다.", HttpStatus.BAD_REQUEST),
+  DELIVERY_NOT_FOUND("DLV-006", "배송 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  DELIVERY_STATE_TRANSITION_INVALID(
+      "DLV-007", "현재 배송 상태에서는 해당 작업을 수행할 수 없습니다.", HttpStatus.CONFLICT),
+  DELIVERY_NO_PERMISSION("DLV-008", "배송 정보에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
   /** GRP - 그룹 관련 에러 */
   GROUP_NOT_FOUND("GRP-001", "존재하지 않는 그룹입니다.", HttpStatus.NOT_FOUND),

--- a/src/test/java/buncheoleasy/buncheol/application/BuncheolServiceTest.java
+++ b/src/test/java/buncheoleasy/buncheol/application/BuncheolServiceTest.java
@@ -1413,4 +1413,80 @@ class BuncheolServiceTest {
       then(buncheolDomainService).should(never()).cancelBuncheol(any());
     }
   }
+
+  @Nested
+  @DisplayName("분철 상태 진행 테스트")
+  class AdvanceBuncheolStatusTest {
+
+    @Test
+    void 개최자가_상태를_정상_진행한다() {
+      // given
+      Long hostId = 1L;
+      Long buncheolId = 10L;
+      Buncheol buncheol = mock(Buncheol.class);
+      given(buncheolDomainService.getBuncheol(buncheolId)).willReturn(buncheol);
+      willDoNothing().given(buncheol).validateOwner(hostId);
+
+      // when
+      buncheolService.advanceBuncheolStatus(
+          hostId, buncheolId, buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED);
+
+      // then
+      then(buncheol).should().validateOwner(hostId);
+      then(buncheolDomainService)
+          .should()
+          .advanceBuncheolStatus(
+              buncheol, buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED);
+    }
+
+    @Test
+    void 개최자가_아니면_예외가_발생한다() {
+      // given
+      Long hostId = 999L;
+      Long buncheolId = 10L;
+      Buncheol buncheol = mock(Buncheol.class);
+      given(buncheolDomainService.getBuncheol(buncheolId)).willReturn(buncheol);
+      willThrow(new BusinessException(ErrorCode.BUNCHEOL_NO_PERMISSION))
+          .given(buncheol)
+          .validateOwner(hostId);
+
+      // when & then
+      assertThatThrownBy(
+              () ->
+                  buncheolService.advanceBuncheolStatus(
+                      hostId,
+                      buncheolId,
+                      buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.BUNCHEOL_NO_PERMISSION);
+
+      then(buncheolDomainService).should(never()).advanceBuncheolStatus(any(), any());
+    }
+
+    @Test
+    void 전이_불가한_상태면_예외가_발생한다() {
+      // given
+      Long hostId = 1L;
+      Long buncheolId = 10L;
+      Buncheol buncheol = mock(Buncheol.class);
+      given(buncheolDomainService.getBuncheol(buncheolId)).willReturn(buncheol);
+      willDoNothing().given(buncheol).validateOwner(hostId);
+      willThrow(new BusinessException(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED))
+          .given(buncheolDomainService)
+          .advanceBuncheolStatus(
+              buncheol, buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED);
+
+      // when & then
+      assertThatThrownBy(
+              () ->
+                  buncheolService.advanceBuncheolStatus(
+                      hostId,
+                      buncheolId,
+                      buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED);
+    }
+  }
 }

--- a/src/test/java/buncheoleasy/buncheol/application/BuncheolServiceTest.java
+++ b/src/test/java/buncheoleasy/buncheol/application/BuncheolServiceTest.java
@@ -1367,13 +1367,17 @@ class BuncheolServiceTest {
       Long buncheolId = 10L;
       Buncheol buncheol = mock(Buncheol.class);
       given(buncheolDomainService.getBuncheol(buncheolId)).willReturn(buncheol);
+      given(buncheol.getStatus())
+          .willReturn(buncheoleasy.buncheol.domain.BuncheolStatus.RECRUITING);
 
       // when
       buncheolService.cancelBuncheol(hostId, buncheolId);
 
       // then
       then(buncheol).should().validateOwner(hostId);
-      then(buncheolDomainService).should().cancelBuncheol(buncheol);
+      then(buncheolDomainService)
+          .should()
+          .cancelBuncheol(buncheol, buncheoleasy.buncheol.domain.BuncheolStatus.RECRUITING);
     }
 
     @Test
@@ -1393,7 +1397,7 @@ class BuncheolServiceTest {
           .extracting("errorCode")
           .isEqualTo(ErrorCode.BUNCHEOL_NO_PERMISSION);
 
-      then(buncheolDomainService).should(never()).cancelBuncheol(any());
+      then(buncheolDomainService).should(never()).cancelBuncheol(any(), any());
     }
 
     @Test
@@ -1410,7 +1414,7 @@ class BuncheolServiceTest {
           .extracting("errorCode")
           .isEqualTo(ErrorCode.BUNCHEOL_NOT_FOUND);
 
-      then(buncheolDomainService).should(never()).cancelBuncheol(any());
+      then(buncheolDomainService).should(never()).cancelBuncheol(any(), any());
     }
   }
 
@@ -1425,6 +1429,7 @@ class BuncheolServiceTest {
       Long buncheolId = 10L;
       Buncheol buncheol = mock(Buncheol.class);
       given(buncheolDomainService.getBuncheol(buncheolId)).willReturn(buncheol);
+      given(buncheol.getStatus()).willReturn(buncheoleasy.buncheol.domain.BuncheolStatus.CLOSED);
       willDoNothing().given(buncheol).validateOwner(hostId);
 
       // when
@@ -1436,7 +1441,9 @@ class BuncheolServiceTest {
       then(buncheolDomainService)
           .should()
           .advanceBuncheolStatus(
-              buncheol, buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED);
+              buncheol,
+              buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED,
+              buncheoleasy.buncheol.domain.BuncheolStatus.CLOSED);
     }
 
     @Test
@@ -1461,7 +1468,7 @@ class BuncheolServiceTest {
           .extracting("errorCode")
           .isEqualTo(ErrorCode.BUNCHEOL_NO_PERMISSION);
 
-      then(buncheolDomainService).should(never()).advanceBuncheolStatus(any(), any());
+      then(buncheolDomainService).should(never()).advanceBuncheolStatus(any(), any(), any());
     }
 
     @Test
@@ -1471,11 +1478,14 @@ class BuncheolServiceTest {
       Long buncheolId = 10L;
       Buncheol buncheol = mock(Buncheol.class);
       given(buncheolDomainService.getBuncheol(buncheolId)).willReturn(buncheol);
+      given(buncheol.getStatus()).willReturn(buncheoleasy.buncheol.domain.BuncheolStatus.CLOSED);
       willDoNothing().given(buncheol).validateOwner(hostId);
       willThrow(new BusinessException(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED))
           .given(buncheolDomainService)
           .advanceBuncheolStatus(
-              buncheol, buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED);
+              buncheol,
+              buncheoleasy.buncheol.domain.BuncheolStatus.GOODS_ORDERED,
+              buncheoleasy.buncheol.domain.BuncheolStatus.CLOSED);
 
       // when & then
       assertThatThrownBy(

--- a/src/test/java/buncheoleasy/buncheol/application/ParticipationPaymentHandlerTest.java
+++ b/src/test/java/buncheoleasy/buncheol/application/ParticipationPaymentHandlerTest.java
@@ -11,17 +11,28 @@ import static org.mockito.Mockito.never;
 import buncheoleasy.buncheol.domain.participation.Participation;
 import buncheoleasy.buncheol.domain.participation.ParticipationDomainService;
 import buncheoleasy.buncheol.domain.participation.ParticipationStatus;
+import buncheoleasy.delivery.domain.Delivery;
+import buncheoleasy.delivery.domain.DeliveryDomainService;
 import buncheoleasy.global.exception.domain.BusinessException;
 import buncheoleasy.global.exception.domain.ErrorCode;
 import buncheoleasy.payment.domain.PaymentPhase;
+import buncheoleasy.user.domain.Nickname;
+import buncheoleasy.user.domain.PhoneNumber;
+import buncheoleasy.user.domain.User;
+import buncheoleasy.user.domain.UserDomainService;
+import buncheoleasy.user.domain.shipping.ShippingAddress;
+import buncheoleasy.user.domain.shipping.ShippingAddressDomainService;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
 import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -34,6 +45,9 @@ class ParticipationPaymentHandlerTest {
   @InjectMocks private ParticipationPaymentHandler participationPaymentHandler;
 
   @Mock private ParticipationDomainService participationDomainService;
+  @Mock private DeliveryDomainService deliveryDomainService;
+  @Mock private ShippingAddressDomainService shippingAddressDomainService;
+  @Mock private UserDomainService userDomainService;
 
   @Spy
   private Clock clock = Clock.fixed(Instant.parse("2026-03-11T12:00:00Z"), ZoneId.of("Asia/Seoul"));
@@ -41,19 +55,43 @@ class ParticipationPaymentHandlerTest {
   private static final Long PARTICIPATION_ID = 1L;
   private static final Long PARTICIPANT_ID = 100L;
   private static final Long BUNCHEOL_MEMBER_ID = 10L;
+  private static final Long SHIPPING_ADDRESS_ID = 200L;
 
   private Participation createInstantParticipation() {
     Participation participation =
-        Participation.createInstant(1L, BUNCHEOL_MEMBER_ID, PARTICIPANT_ID, 200L, 50_000L);
+        Participation.createInstant(
+            1L, BUNCHEOL_MEMBER_ID, PARTICIPANT_ID, SHIPPING_ADDRESS_ID, 50_000L);
     setId(participation, PARTICIPATION_ID);
     return participation;
   }
 
   private Participation createBidParticipation() {
     Participation participation =
-        Participation.createBid(1L, BUNCHEOL_MEMBER_ID, PARTICIPANT_ID, 200L, 30_000L);
+        Participation.createBid(
+            1L, BUNCHEOL_MEMBER_ID, PARTICIPANT_ID, SHIPPING_ADDRESS_ID, 30_000L);
     setId(participation, PARTICIPATION_ID);
     return participation;
+  }
+
+  private void stubDeliverySnapshot() {
+    ShippingAddress shippingAddress =
+        new ShippingAddress(
+            SHIPPING_ADDRESS_ID,
+            PARTICIPANT_ID,
+            ShippingMethod.GS25_HALF,
+            "GS25 강남점",
+            LocalDateTime.now(),
+            LocalDateTime.now());
+    given(shippingAddressDomainService.getShippingAddress(SHIPPING_ADDRESS_ID))
+        .willReturn(shippingAddress);
+
+    User user = User.create("KAKAO", "kakao123", "test@test.com");
+    setFieldValue(user, "nickname", Nickname.of("TestUser"));
+    setFieldValue(user, "phoneNumber", PhoneNumber.of("01012345678"));
+    given(userDomainService.getUser(PARTICIPANT_ID)).willReturn(user);
+
+    given(deliveryDomainService.createDelivery(any(Delivery.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
   }
 
   @Nested
@@ -110,6 +148,7 @@ class ParticipationPaymentHandlerTest {
       then(participationDomainService)
           .should()
           .failAllOpenBids(eq(BUNCHEOL_MEMBER_ID), any(String.class));
+      then(deliveryDomainService).should(never()).createDelivery(any());
     }
 
     @Test
@@ -128,6 +167,7 @@ class ParticipationPaymentHandlerTest {
           .should()
           .updateParticipationStatus(participation, ParticipationStatus.PAYMENT_PENDING);
       then(participationDomainService).should(never()).failAllOpenBids(any(), any());
+      then(deliveryDomainService).should(never()).createDelivery(any());
     }
 
     @Test
@@ -137,6 +177,7 @@ class ParticipationPaymentHandlerTest {
       setStatus(participation, ParticipationStatus.AWAITING_BALANCE_PAYMENT);
       given(participationDomainService.getParticipation(PARTICIPATION_ID))
           .willReturn(participation);
+      stubDeliverySnapshot();
 
       // when
       participationPaymentHandler.onPaymentCompleted(PARTICIPATION_ID, PaymentPhase.BALANCE);
@@ -148,6 +189,66 @@ class ParticipationPaymentHandlerTest {
           .should()
           .updateParticipationStatus(participation, ParticipationStatus.AWAITING_BALANCE_PAYMENT);
       then(participationDomainService).should(never()).failAllOpenBids(any(), any());
+    }
+  }
+
+  @Nested
+  @DisplayName("배송 스냅샷 생성 테스트")
+  class DeliverySnapshotTest {
+
+    @Test
+    void 즉시_구매_결제_완료시_배송_스냅샷이_생성되지_않는다() {
+      // INSTANT 확정 참여의 배송 스냅샷은 분철 마감 시점에 일괄 생성
+      // given
+      Participation participation = createInstantParticipation();
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+
+      // when
+      participationPaymentHandler.onPaymentCompleted(PARTICIPATION_ID, PaymentPhase.INSTANT);
+
+      // then
+      then(deliveryDomainService).should(never()).createDelivery(any());
+    }
+
+    @Test
+    void 잔금_결제_완료시_배송_스냅샷이_생성된다() {
+      // given
+      Participation participation = createBidParticipation();
+      setStatus(participation, ParticipationStatus.AWAITING_BALANCE_PAYMENT);
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+      stubDeliverySnapshot();
+
+      // when
+      participationPaymentHandler.onPaymentCompleted(PARTICIPATION_ID, PaymentPhase.BALANCE);
+
+      // then
+      ArgumentCaptor<Delivery> deliveryCaptor = ArgumentCaptor.forClass(Delivery.class);
+      then(deliveryDomainService).should().createDelivery(deliveryCaptor.capture());
+
+      Delivery delivery = deliveryCaptor.getValue();
+      assertThat(delivery.getParticipationId()).isEqualTo(PARTICIPATION_ID);
+      assertThat(delivery.getShippingMethod()).isEqualTo(ShippingMethod.GS25_HALF);
+      assertThat(delivery.getStoreName()).isEqualTo("GS25 강남점");
+      assertThat(delivery.getReceiverNickname()).isEqualTo("TestUser");
+      assertThat(delivery.getReceiverPhoneNumber()).isEqualTo("01012345678");
+    }
+
+    @Test
+    void 예치금_결제_완료시_배송_스냅샷이_생성되지_않는다() {
+      // given
+      Participation participation = createBidParticipation();
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+
+      // when
+      participationPaymentHandler.onPaymentCompleted(PARTICIPATION_ID, PaymentPhase.DEPOSIT);
+
+      // then
+      then(deliveryDomainService).should(never()).createDelivery(any());
+      then(shippingAddressDomainService).should(never()).getShippingAddress(any());
+      then(userDomainService).should(never()).getUser(any());
     }
   }
 

--- a/src/test/java/buncheoleasy/buncheol/domain/BuncheolStatusTest.java
+++ b/src/test/java/buncheoleasy/buncheol/domain/BuncheolStatusTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -28,6 +29,43 @@ class BuncheolStatusTest {
         names = {"HOST_SHIPPING", "ALL_RECEIVED", "SETTLING", "SETTLED", "FINISHED", "CANCELLED"})
     void 취소_불가_상태이면_false를_반환한다(BuncheolStatus status) {
       assertThat(status.isCancellable()).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("상태 전이 가능 여부 테스트")
+  class CanAdvanceToTest {
+
+    @Test
+    void CLOSED에서_GOODS_ORDERED로_전이_가능하다() {
+      assertThat(BuncheolStatus.CLOSED.canAdvanceTo(BuncheolStatus.GOODS_ORDERED)).isTrue();
+    }
+
+    @Test
+    void GOODS_ORDERED에서_SELLER_SHIPPING으로_전이_가능하다() {
+      assertThat(BuncheolStatus.GOODS_ORDERED.canAdvanceTo(BuncheolStatus.SELLER_SHIPPING))
+          .isTrue();
+    }
+
+    @Test
+    void CLOSED에서_SELLER_SHIPPING으로_전이_불가하다() {
+      assertThat(BuncheolStatus.CLOSED.canAdvanceTo(BuncheolStatus.SELLER_SHIPPING)).isFalse();
+    }
+
+    @Test
+    void GOODS_ORDERED에서_GOODS_ORDERED로_전이_불가하다() {
+      assertThat(BuncheolStatus.GOODS_ORDERED.canAdvanceTo(BuncheolStatus.GOODS_ORDERED)).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = BuncheolStatus.class,
+        names = {"CLOSED", "GOODS_ORDERED"},
+        mode = EnumSource.Mode.EXCLUDE)
+    void CLOSED와_GOODS_ORDERED_외_상태에서는_전이_불가하다(BuncheolStatus status) {
+      for (BuncheolStatus target : BuncheolStatus.values()) {
+        assertThat(status.canAdvanceTo(target)).isFalse();
+      }
     }
   }
 }

--- a/src/test/java/buncheoleasy/buncheol/domain/BuncheolTest.java
+++ b/src/test/java/buncheoleasy/buncheol/domain/BuncheolTest.java
@@ -576,6 +576,59 @@ class BuncheolTest {
     }
   }
 
+  @Nested
+  @DisplayName("상태 진행 테스트")
+  class AdvanceStatusTest {
+
+    @Test
+    void CLOSED에서_GOODS_ORDERED로_상태_전이에_성공한다() {
+      // given
+      Buncheol buncheol = Buncheol.create(HOST_ID, validParams());
+      setStatus(buncheol, BuncheolStatus.CLOSED);
+
+      // when
+      buncheol.advanceStatus(BuncheolStatus.GOODS_ORDERED);
+
+      // then
+      assertThat(buncheol.getStatus()).isEqualTo(BuncheolStatus.GOODS_ORDERED);
+    }
+
+    @Test
+    void GOODS_ORDERED에서_SELLER_SHIPPING으로_상태_전이에_성공한다() {
+      // given
+      Buncheol buncheol = Buncheol.create(HOST_ID, validParams());
+      setStatus(buncheol, BuncheolStatus.GOODS_ORDERED);
+
+      // when
+      buncheol.advanceStatus(BuncheolStatus.SELLER_SHIPPING);
+
+      // then
+      assertThat(buncheol.getStatus()).isEqualTo(BuncheolStatus.SELLER_SHIPPING);
+    }
+
+    @Test
+    void 허용되지_않은_전이시_예외가_발생한다() {
+      // given
+      Buncheol buncheol = Buncheol.create(HOST_ID, validParams());
+
+      // when & then (RECRUITING → GOODS_ORDERED 불가)
+      assertThatThrownBy(() -> buncheol.advanceStatus(BuncheolStatus.GOODS_ORDERED))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED);
+    }
+  }
+
+  private void setStatus(final Buncheol buncheol, final BuncheolStatus status) {
+    try {
+      Field statusField = Buncheol.class.getDeclaredField("status");
+      statusField.setAccessible(true);
+      statusField.set(buncheol, status);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private void setDeadline(final Buncheol buncheol, final LocalDateTime deadline) {
     try {
       Field deadlineField = Buncheol.class.getDeclaredField("deadline");

--- a/src/test/java/buncheoleasy/buncheol/infrastructure/BuncheolMapperTest.java
+++ b/src/test/java/buncheoleasy/buncheol/infrastructure/BuncheolMapperTest.java
@@ -202,13 +202,32 @@ class BuncheolMapperTest {
       // given
       Buncheol buncheol = Buncheol.create(hostId, validParams("상태 그룹"));
       buncheolMapper.insert(buncheol);
+      BuncheolStatus expectedStatus = buncheol.getStatus();
+      buncheol.cancel();
 
       // when
-      buncheolMapper.updateStatus(buncheol.getId(), BuncheolStatus.CANCELLED);
+      int updated = buncheolMapper.updateStatus(buncheol, expectedStatus);
       Buncheol found = buncheolMapper.findById(buncheol.getId()).orElseThrow();
 
       // then
+      assertThat(updated).isEqualTo(1);
       assertThat(found.getStatus()).isEqualTo(BuncheolStatus.CANCELLED);
+    }
+
+    @Test
+    void 예상_상태가_다르면_업데이트되지_않는다() {
+      // given
+      Buncheol buncheol = Buncheol.create(hostId, validParams("낙관적 잠금"));
+      buncheolMapper.insert(buncheol);
+      buncheol.cancel();
+
+      // when — expectedStatus를 CLOSED로 전달 (실제는 RECRUITING)
+      int updated = buncheolMapper.updateStatus(buncheol, BuncheolStatus.CLOSED);
+      Buncheol found = buncheolMapper.findById(buncheol.getId()).orElseThrow();
+
+      // then
+      assertThat(updated).isEqualTo(0);
+      assertThat(found.getStatus()).isEqualTo(BuncheolStatus.RECRUITING);
     }
   }
 }

--- a/src/test/java/buncheoleasy/buncheol/presentation/BuncheolControllerTest.java
+++ b/src/test/java/buncheoleasy/buncheol/presentation/BuncheolControllerTest.java
@@ -6,11 +6,13 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
 import buncheoleasy.buncheol.application.BuncheolService;
+import buncheoleasy.buncheol.domain.BuncheolStatus;
 import buncheoleasy.global.exception.domain.BusinessException;
 import buncheoleasy.global.exception.domain.ErrorCode;
 import java.time.LocalDateTime;
@@ -546,6 +548,58 @@ class BuncheolControllerTest {
                   .string(
                       org.hamcrest.Matchers.containsString(
                           ErrorCode.BUNCHEOL_NO_PERMISSION.getCode())));
+    }
+  }
+
+  @Nested
+  @DisplayName("분철 상태 진행 API 테스트")
+  class AdvanceBuncheolStatusTest {
+
+    @Test
+    void 정상_요청시_204를_반환한다() throws Exception {
+      // when & then
+      mockMvc
+          .perform(
+              patch("/v1/buncheols/{id}/status", 10L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"status\": \"GOODS_ORDERED\"}"))
+          .andExpect(status().isNoContent());
+
+      then(buncheolService)
+          .should()
+          .advanceBuncheolStatus(HOST_ID, 10L, BuncheolStatus.GOODS_ORDERED);
+    }
+
+    @Test
+    void status가_없으면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              patch("/v1/buncheols/{id}/status", 10L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 전이_불가한_상태면_409를_반환한다() throws Exception {
+      willThrow(new BusinessException(ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED))
+          .given(buncheolService)
+          .advanceBuncheolStatus(HOST_ID, 10L, BuncheolStatus.GOODS_ORDERED);
+
+      mockMvc
+          .perform(
+              patch("/v1/buncheols/{id}/status", 10L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"status\": \"GOODS_ORDERED\"}"))
+          .andExpect(status().isConflict())
+          .andExpect(
+              content()
+                  .string(
+                      org.hamcrest.Matchers.containsString(
+                          ErrorCode.BUNCHEOL_STATUS_ADVANCE_NOT_ALLOWED.getCode())));
     }
   }
 }

--- a/src/test/java/buncheoleasy/delivery/application/DeliveryServiceTest.java
+++ b/src/test/java/buncheoleasy/delivery/application/DeliveryServiceTest.java
@@ -1,0 +1,168 @@
+package buncheoleasy.delivery.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+
+import buncheoleasy.buncheol.domain.Buncheol;
+import buncheoleasy.buncheol.domain.BuncheolDomainService;
+import buncheoleasy.buncheol.domain.participation.Participation;
+import buncheoleasy.buncheol.domain.participation.ParticipationDomainService;
+import buncheoleasy.delivery.domain.Delivery;
+import buncheoleasy.delivery.domain.DeliveryDomainService;
+import buncheoleasy.delivery.domain.DeliveryStatus;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
+import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeliveryService 단위 테스트")
+class DeliveryServiceTest {
+
+  @InjectMocks private DeliveryService deliveryService;
+
+  @Mock private DeliveryDomainService deliveryDomainService;
+  @Mock private ParticipationDomainService participationDomainService;
+  @Mock private BuncheolDomainService buncheolDomainService;
+
+  @Spy
+  private Clock clock = Clock.fixed(Instant.parse("2026-03-23T12:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+  private static final Long HOST_ID = 1L;
+  private static final Long PARTICIPANT_ID = 100L;
+  private static final Long DELIVERY_ID = 10L;
+  private static final Long PARTICIPATION_ID = 20L;
+  private static final Long BUNCHEOL_ID = 30L;
+
+  private Delivery createSnapshotDelivery() {
+    Delivery delivery =
+        Delivery.createSnapshot(
+            PARTICIPATION_ID, ShippingMethod.GS25_HALF, "GS25 강남점", "테스트유저", "01012345678");
+    setField(delivery, "id", DELIVERY_ID);
+    return delivery;
+  }
+
+  @Nested
+  @DisplayName("운송장 등록 테스트")
+  class RegisterTrackingTest {
+
+    @Test
+    void 개최자가_운송장을_정상_등록한다() {
+      // given
+      Delivery delivery = createSnapshotDelivery();
+      Participation participation = mock(Participation.class);
+      given(participation.getBuncheolId()).willReturn(BUNCHEOL_ID);
+      Buncheol buncheol = mock(Buncheol.class);
+
+      given(deliveryDomainService.getDelivery(DELIVERY_ID)).willReturn(delivery);
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+      given(buncheolDomainService.getBuncheol(BUNCHEOL_ID)).willReturn(buncheol);
+      willDoNothing().given(buncheol).validateOwner(HOST_ID);
+
+      // when
+      deliveryService.registerTracking(HOST_ID, DELIVERY_ID, "TRACK123");
+
+      // then
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.SHIPPING);
+      assertThat(delivery.getTrackingNumber()).isEqualTo("TRACK123");
+      then(deliveryDomainService)
+          .should()
+          .updateDeliveryStatus(delivery, DeliveryStatus.SNAPSHOTTED);
+    }
+
+    @Test
+    void 개최자가_아니면_예외가_발생한다() {
+      // given
+      Delivery delivery = createSnapshotDelivery();
+      Participation participation = mock(Participation.class);
+      given(participation.getBuncheolId()).willReturn(BUNCHEOL_ID);
+      Buncheol buncheol = mock(Buncheol.class);
+
+      given(deliveryDomainService.getDelivery(DELIVERY_ID)).willReturn(delivery);
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+      given(buncheolDomainService.getBuncheol(BUNCHEOL_ID)).willReturn(buncheol);
+      willThrow(new BusinessException(ErrorCode.BUNCHEOL_NO_PERMISSION))
+          .given(buncheol)
+          .validateOwner(999L);
+
+      // when & then
+      assertThatThrownBy(() -> deliveryService.registerTracking(999L, DELIVERY_ID, "TRACK123"))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.BUNCHEOL_NO_PERMISSION);
+    }
+  }
+
+  @Nested
+  @DisplayName("수령 확인 테스트")
+  class ConfirmReceiptTest {
+
+    @Test
+    void 참여자_본인이_수령_확인한다() {
+      // given
+      Delivery delivery = createSnapshotDelivery();
+      delivery.registerTracking("TRACK123", LocalDateTime.now(clock));
+      Participation participation = mock(Participation.class);
+      given(participation.getParticipantId()).willReturn(PARTICIPANT_ID);
+
+      given(deliveryDomainService.getDelivery(DELIVERY_ID)).willReturn(delivery);
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+
+      // when
+      deliveryService.confirmReceipt(PARTICIPANT_ID, DELIVERY_ID);
+
+      // then
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.RECEIVED);
+      assertThat(delivery.getReceivedAt()).isNotNull();
+      then(deliveryDomainService).should().updateDeliveryStatus(delivery, DeliveryStatus.SHIPPING);
+    }
+
+    @Test
+    void 참여자_본인이_아니면_예외가_발생한다() {
+      // given
+      Delivery delivery = createSnapshotDelivery();
+      Participation participation = mock(Participation.class);
+      given(participation.getParticipantId()).willReturn(PARTICIPANT_ID);
+
+      given(deliveryDomainService.getDelivery(DELIVERY_ID)).willReturn(delivery);
+      given(participationDomainService.getParticipation(PARTICIPATION_ID))
+          .willReturn(participation);
+
+      // when & then
+      assertThatThrownBy(() -> deliveryService.confirmReceipt(999L, DELIVERY_ID))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_NO_PERMISSION);
+    }
+  }
+
+  private void setField(final Object target, final String fieldName, final Object value) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/buncheoleasy/delivery/domain/DeliveryDomainServiceTest.java
+++ b/src/test/java/buncheoleasy/delivery/domain/DeliveryDomainServiceTest.java
@@ -1,0 +1,142 @@
+package buncheoleasy.delivery.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeliveryDomainService 단위 테스트")
+class DeliveryDomainServiceTest {
+
+  @InjectMocks private DeliveryDomainService deliveryDomainService;
+
+  @Mock private DeliveryRepository deliveryRepository;
+
+  private Delivery createDelivery() {
+    return Delivery.createSnapshot(
+        1L, ShippingMethod.GS25_HALF, "GS25 강남점", "테스트유저", "01012345678");
+  }
+
+  @Nested
+  @DisplayName("createDelivery 테스트")
+  class CreateDeliveryTest {
+
+    @Test
+    void 배송_정보를_정상_저장한다() {
+      // given
+      Delivery delivery = createDelivery();
+      given(deliveryRepository.save(delivery)).willReturn(delivery);
+
+      // when
+      Delivery result = deliveryDomainService.createDelivery(delivery);
+
+      // then
+      assertThat(result).isEqualTo(delivery);
+      then(deliveryRepository).should().save(delivery);
+    }
+  }
+
+  @Nested
+  @DisplayName("getDelivery 테스트")
+  class GetDeliveryTest {
+
+    @Test
+    void 존재하는_배송_정보를_반환한다() {
+      // given
+      Delivery delivery = createDelivery();
+      given(deliveryRepository.findById(1L)).willReturn(Optional.of(delivery));
+
+      // when
+      Delivery result = deliveryDomainService.getDelivery(1L);
+
+      // then
+      assertThat(result).isEqualTo(delivery);
+    }
+
+    @Test
+    void 존재하지_않으면_예외가_발생한다() {
+      // given
+      given(deliveryRepository.findById(999L)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> deliveryDomainService.getDelivery(999L))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("getDeliveryByParticipationId 테스트")
+  class GetDeliveryByParticipationIdTest {
+
+    @Test
+    void 참여_ID로_배송_정보를_반환한다() {
+      // given
+      Delivery delivery = createDelivery();
+      given(deliveryRepository.findByParticipationId(1L)).willReturn(Optional.of(delivery));
+
+      // when
+      Delivery result = deliveryDomainService.getDeliveryByParticipationId(1L);
+
+      // then
+      assertThat(result).isEqualTo(delivery);
+    }
+
+    @Test
+    void 존재하지_않으면_예외가_발생한다() {
+      // given
+      given(deliveryRepository.findByParticipationId(999L)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> deliveryDomainService.getDeliveryByParticipationId(999L))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("updateDeliveryStatus 테스트")
+  class UpdateDeliveryStatusTest {
+
+    @Test
+    void 상태_업데이트가_성공하면_예외가_발생하지_않는다() {
+      // given
+      Delivery delivery = createDelivery();
+      given(deliveryRepository.updateStatus(delivery, DeliveryStatus.SNAPSHOTTED)).willReturn(true);
+
+      // when & then (예외 없이 완료)
+      deliveryDomainService.updateDeliveryStatus(delivery, DeliveryStatus.SNAPSHOTTED);
+    }
+
+    @Test
+    void 상태_업데이트가_실패하면_예외가_발생한다() {
+      // given
+      Delivery delivery = createDelivery();
+      given(deliveryRepository.updateStatus(delivery, DeliveryStatus.SNAPSHOTTED))
+          .willReturn(false);
+
+      // when & then
+      assertThatThrownBy(
+              () ->
+                  deliveryDomainService.updateDeliveryStatus(delivery, DeliveryStatus.SNAPSHOTTED))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+  }
+}

--- a/src/test/java/buncheoleasy/delivery/domain/DeliveryTest.java
+++ b/src/test/java/buncheoleasy/delivery/domain/DeliveryTest.java
@@ -1,0 +1,213 @@
+package buncheoleasy.delivery.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import buncheoleasy.user.domain.shipping.ShippingMethod;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Delivery 도메인 단위 테스트")
+class DeliveryTest {
+
+  private static final Long PARTICIPATION_ID = 1L;
+  private static final ShippingMethod SHIPPING_METHOD = ShippingMethod.GS25_HALF;
+  private static final String STORE_NAME = "GS25 강남점";
+  private static final String RECEIVER_NICKNAME = "테스트유저";
+  private static final String RECEIVER_PHONE = "01012345678";
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 23, 12, 0);
+
+  @Nested
+  @DisplayName("createSnapshot 테스트")
+  class CreateSnapshotTest {
+
+    @Test
+    void 배송_스냅샷이_정상_생성된다() {
+      Delivery delivery =
+          Delivery.createSnapshot(
+              PARTICIPATION_ID, SHIPPING_METHOD, STORE_NAME, RECEIVER_NICKNAME, RECEIVER_PHONE);
+
+      assertThat(delivery.getParticipationId()).isEqualTo(PARTICIPATION_ID);
+      assertThat(delivery.getShippingMethod()).isEqualTo(SHIPPING_METHOD);
+      assertThat(delivery.getStoreName()).isEqualTo(STORE_NAME);
+      assertThat(delivery.getReceiverNickname()).isEqualTo(RECEIVER_NICKNAME);
+      assertThat(delivery.getReceiverPhoneNumber()).isEqualTo(RECEIVER_PHONE);
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.SNAPSHOTTED);
+      assertThat(delivery.getTrackingNumber()).isNull();
+    }
+
+    @Test
+    void 배송방법이_null이면_예외가_발생한다() {
+      assertThatThrownBy(
+              () ->
+                  Delivery.createSnapshot(
+                      PARTICIPATION_ID, null, STORE_NAME, RECEIVER_NICKNAME, RECEIVER_PHONE))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_SHIPPING_METHOD_REQUIRED);
+    }
+
+    @Test
+    void 지점명이_비어있으면_예외가_발생한다() {
+      assertThatThrownBy(
+              () ->
+                  Delivery.createSnapshot(
+                      PARTICIPATION_ID, SHIPPING_METHOD, "", RECEIVER_NICKNAME, RECEIVER_PHONE))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_STORE_NAME_REQUIRED);
+    }
+
+    @Test
+    void 수령인_닉네임이_null이면_예외가_발생한다() {
+      assertThatThrownBy(
+              () ->
+                  Delivery.createSnapshot(
+                      PARTICIPATION_ID, SHIPPING_METHOD, STORE_NAME, null, RECEIVER_PHONE))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_RECEIVER_NICKNAME_REQUIRED);
+    }
+
+    @Test
+    void 수령인_연락처가_null이면_예외가_발생한다() {
+      assertThatThrownBy(
+              () ->
+                  Delivery.createSnapshot(
+                      PARTICIPATION_ID, SHIPPING_METHOD, STORE_NAME, RECEIVER_NICKNAME, null))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_RECEIVER_PHONE_REQUIRED);
+    }
+  }
+
+  @Nested
+  @DisplayName("registerTracking 테스트")
+  class RegisterTrackingTest {
+
+    @Test
+    void SNAPSHOTTED_상태에서_운송장_등록시_SHIPPING으로_전이된다() {
+      Delivery delivery = createSnapshotDelivery();
+
+      delivery.registerTracking("TRACK123", NOW);
+
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.SHIPPING);
+      assertThat(delivery.getTrackingNumber()).isEqualTo("TRACK123");
+      assertThat(delivery.getTrackingRegisteredAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void SHIPPING_상태에서_운송장_등록시_운송장_번호만_업데이트된다() {
+      Delivery delivery = createSnapshotDelivery();
+      delivery.registerTracking("TRACK123", NOW);
+
+      LocalDateTime later = NOW.plusHours(1);
+      delivery.registerTracking("TRACK456", later);
+
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.SHIPPING);
+      assertThat(delivery.getTrackingNumber()).isEqualTo("TRACK456");
+      assertThat(delivery.getTrackingRegisteredAt()).isEqualTo(later);
+    }
+
+    @Test
+    void 운송장_번호가_null이면_예외가_발생한다() {
+      Delivery delivery = createSnapshotDelivery();
+
+      assertThatThrownBy(() -> delivery.registerTracking(null, NOW))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_TRACKING_NUMBER_REQUIRED);
+    }
+
+    @Test
+    void 운송장_번호가_빈_문자열이면_예외가_발생한다() {
+      Delivery delivery = createSnapshotDelivery();
+
+      assertThatThrownBy(() -> delivery.registerTracking("  ", NOW))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_TRACKING_NUMBER_REQUIRED);
+    }
+
+    @Test
+    void RECEIVED_상태에서_운송장_등록시_예외가_발생한다() {
+      Delivery delivery = createSnapshotDelivery();
+      delivery.registerTracking("TRACK123", NOW);
+      delivery.confirmReceipt(NOW.plusDays(1));
+
+      assertThatThrownBy(() -> delivery.registerTracking("TRACK999", NOW.plusDays(2)))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+  }
+
+  @Nested
+  @DisplayName("confirmReceipt 테스트")
+  class ConfirmReceiptTest {
+
+    @Test
+    void SHIPPING_상태에서_수령_완료시_RECEIVED로_전이된다() {
+      Delivery delivery = createSnapshotDelivery();
+      delivery.registerTracking("TRACK123", NOW);
+
+      delivery.confirmReceipt(NOW.plusDays(1));
+
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.RECEIVED);
+      assertThat(delivery.getReceivedAt()).isEqualTo(NOW.plusDays(1));
+    }
+
+    @Test
+    void DELIVERED_상태에서_수령_완료시_RECEIVED로_전이된다() {
+      Delivery delivery = createSnapshotDelivery();
+      delivery.registerTracking("TRACK123", NOW);
+      setField(delivery, "status", DeliveryStatus.DELIVERED);
+
+      delivery.confirmReceipt(NOW.plusDays(1));
+
+      assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.RECEIVED);
+    }
+
+    @Test
+    void SNAPSHOTTED_상태에서_수령_완료시_예외가_발생한다() {
+      Delivery delivery = createSnapshotDelivery();
+
+      assertThatThrownBy(() -> delivery.confirmReceipt(NOW))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+
+    @Test
+    void RECEIVED_상태에서_수령_완료시_예외가_발생한다() {
+      Delivery delivery = createSnapshotDelivery();
+      delivery.registerTracking("TRACK123", NOW);
+      delivery.confirmReceipt(NOW.plusDays(1));
+
+      assertThatThrownBy(() -> delivery.confirmReceipt(NOW.plusDays(2)))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID);
+    }
+  }
+
+  private Delivery createSnapshotDelivery() {
+    return Delivery.createSnapshot(
+        PARTICIPATION_ID, SHIPPING_METHOD, STORE_NAME, RECEIVER_NICKNAME, RECEIVER_PHONE);
+  }
+
+  private void setField(final Object target, final String fieldName, final Object value) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/buncheoleasy/delivery/presentation/DeliveryControllerTest.java
+++ b/src/test/java/buncheoleasy/delivery/presentation/DeliveryControllerTest.java
@@ -1,0 +1,163 @@
+package buncheoleasy.delivery.presentation;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import buncheoleasy.auth.infrastructure.jwt.JwtTokenProvider;
+import buncheoleasy.delivery.application.DeliveryService;
+import buncheoleasy.global.exception.domain.BusinessException;
+import buncheoleasy.global.exception.domain.ErrorCode;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("DeliveryController 테스트")
+class DeliveryControllerTest {
+
+  private static final Long USER_ID = 1L;
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private DeliveryService deliveryService;
+
+  @MockitoBean private JwtTokenProvider jwtTokenProvider;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private RequestPostProcessor mockAuth() {
+    return (MockHttpServletRequest request) -> {
+      SecurityContextHolder.getContext()
+          .setAuthentication(
+              new UsernamePasswordAuthenticationToken(USER_ID, null, Collections.emptyList()));
+      return request;
+    };
+  }
+
+  @Nested
+  @DisplayName("운송장 등록 API 테스트")
+  class RegisterTrackingTest {
+
+    @Test
+    void 정상_요청시_204를_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              patch("/v1/deliveries/{id}/tracking", 10L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"trackingNumber\": \"TRACK123\"}"))
+          .andExpect(status().isNoContent());
+
+      then(deliveryService).should().registerTracking(USER_ID, 10L, "TRACK123");
+    }
+
+    @Test
+    void trackingNumber가_비어있으면_400을_반환한다() throws Exception {
+      mockMvc
+          .perform(
+              patch("/v1/deliveries/{id}/tracking", 10L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"trackingNumber\": \"\"}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 권한이_없으면_403을_반환한다() throws Exception {
+      willThrow(new BusinessException(ErrorCode.BUNCHEOL_NO_PERMISSION))
+          .given(deliveryService)
+          .registerTracking(USER_ID, 10L, "TRACK123");
+
+      mockMvc
+          .perform(
+              patch("/v1/deliveries/{id}/tracking", 10L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"trackingNumber\": \"TRACK123\"}"))
+          .andExpect(status().isForbidden())
+          .andExpect(
+              content()
+                  .string(
+                      org.hamcrest.Matchers.containsString(
+                          ErrorCode.BUNCHEOL_NO_PERMISSION.getCode())));
+    }
+
+    @Test
+    void 배송_정보가_없으면_404를_반환한다() throws Exception {
+      willThrow(new BusinessException(ErrorCode.DELIVERY_NOT_FOUND))
+          .given(deliveryService)
+          .registerTracking(USER_ID, 999L, "TRACK123");
+
+      mockMvc
+          .perform(
+              patch("/v1/deliveries/{id}/tracking", 999L)
+                  .with(mockAuth())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"trackingNumber\": \"TRACK123\"}"))
+          .andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  @DisplayName("수령 확인 API 테스트")
+  class ConfirmReceiptTest {
+
+    @Test
+    void 정상_요청시_204를_반환한다() throws Exception {
+      mockMvc
+          .perform(post("/v1/deliveries/{id}/receipt", 10L).with(mockAuth()))
+          .andExpect(status().isNoContent());
+
+      then(deliveryService).should().confirmReceipt(USER_ID, 10L);
+    }
+
+    @Test
+    void 권한이_없으면_403을_반환한다() throws Exception {
+      willThrow(new BusinessException(ErrorCode.DELIVERY_NO_PERMISSION))
+          .given(deliveryService)
+          .confirmReceipt(USER_ID, 10L);
+
+      mockMvc
+          .perform(post("/v1/deliveries/{id}/receipt", 10L).with(mockAuth()))
+          .andExpect(status().isForbidden())
+          .andExpect(
+              content()
+                  .string(
+                      org.hamcrest.Matchers.containsString(
+                          ErrorCode.DELIVERY_NO_PERMISSION.getCode())));
+    }
+
+    @Test
+    void 상태_전이가_불가하면_409를_반환한다() throws Exception {
+      willThrow(new BusinessException(ErrorCode.DELIVERY_STATE_TRANSITION_INVALID))
+          .given(deliveryService)
+          .confirmReceipt(USER_ID, 10L);
+
+      mockMvc
+          .perform(post("/v1/deliveries/{id}/receipt", 10L).with(mockAuth()))
+          .andExpect(status().isConflict());
+    }
+  }
+}

--- a/src/test/resources/schema-test.sql
+++ b/src/test/resources/schema-test.sql
@@ -1,5 +1,6 @@
 -- Test H2 Database용 테이블 생성
 -- FK 역순으로 DROP (자식 → 부모 순서)
+DROP TABLE IF EXISTS deliveries;
 DROP TABLE IF EXISTS payments;
 DROP TABLE IF EXISTS participations;
 DROP TABLE IF EXISTS buncheol_images;
@@ -206,3 +207,26 @@ CREATE TABLE payments
 
 CREATE INDEX idx_payments_participation_id ON payments (participation_id);
 CREATE INDEX idx_payments_tx_type_status ON payments (tx_type, status);
+
+CREATE TABLE deliveries
+(
+    id                     BIGINT       NOT NULL AUTO_INCREMENT,
+    participation_id       BIGINT       NOT NULL,
+    shipping_method        VARCHAR(20)  NOT NULL,
+    store_name             VARCHAR(100) NOT NULL,
+    receiver_nickname      VARCHAR(20)  NOT NULL,
+    receiver_phone_number  VARCHAR(15)  NOT NULL,
+    tracking_number        VARCHAR(100) NULL,
+    tracking_registered_at TIMESTAMP    NULL,
+    delivered_at           TIMESTAMP    NULL,
+    received_at            TIMESTAMP    NULL,
+    status                 VARCHAR(20)  NOT NULL DEFAULT 'SNAPSHOTTED',
+    created_at             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_deliveries_participation FOREIGN KEY (participation_id) REFERENCES participations (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX uq_deliveries_participation_id ON deliveries (participation_id);
+CREATE INDEX idx_deliveries_status ON deliveries (status);


### PR DESCRIPTION
## 관련 이슈
- close #26

## 구현 내용
분철 마감 이후 개최자가 진행 단계를 관리하고, 배송을 추적할 수 있는 API를 구현했습니다.

**Delivery 도메인**                     
  - DeliveryStatus 상태 머신: `SNAPSHOTTED` → `SHIPPING` → `DELIVERED` → `RECEIVED`
    - `SHIPPING` 상태에서 운송장 번호 재등록 가능 (번호 수정)                                  
    - `DELIVERED`는 택배사 API 연동으로 시스템이 설정 (별도 태스크에서 진행 예정)
    - `SHIPPING`, `DELIVERED` 두 상태에서 `RECEIVED` 전이 허용   
                                                                                                  
**배송 스냅샷 생성 시점**                                                                           
                                                                    
  - 제시 참여: 잔금 결제 완료 시점에 스냅샷 생성
  - 즉시 구매 참여: 분철 마감 시점에 일괄 스냅샷 생성 예정 (마감 로직에서 함께 처리 예정, 구현X)
                                                                                                  
  **분철 상태 진행 API (개최자용)**                  
```                                                                                      
  PATCH /v1/buncheols/{id}/status                                                                 
  Body: {"status": "GOODS_ORDERED"}                                                               
```
  - 개최자만 호출 가능                                                                            
  - 허용 전이: `CLOSED` → `GOODS_ORDERED` → `SELLER_SHIPPING` (한 단계씩만)
                                                                                                  
  **운송장 등록 API (개최자용)**                                                                      
```                                                                            
  PATCH /v1/deliveries/{id}/tracking                        
  Body: {"trackingNumber": "TRACK123"}                                                            
```
                                                                                                  
  **수령 완료 API (참여자용)**                                                                        
```                                                        
  POST /v1/deliveries/{id}/receipt                                                                
```

### 관련 추후 태스크
  - 분철 마감 로직 구현 - BID 낙찰 순위 산정 + INSTANT 확정 참여의 배송 스냅샷 일괄 생성
  - 배달 완료 추적 - 택배사 API 연동으로 운송장 번호 기반 배달 상태 조회 (`SHIPPING` → `DELIVERED`)
  - 자동 수령 확정 - `DELIVERED` 후 일정 기간 경과 시 자동 `RECEIVED` 전환 (참여자의 무한 미수령 상태 방지용)